### PR TITLE
Fixed reactivator and proxy image issue and updated test scripts for building comfort

### DIFF
--- a/e2e-test-framework/examples/building_comfort/drasi/run_test_with_memory.sh
+++ b/e2e-test-framework/examples/building_comfort/drasi/run_test_with_memory.sh
@@ -17,6 +17,7 @@
 GREEN="\033[32m"
 RESET="\033[0m"
 
+drasi env kube
 echo -e "${GREEN}\n\nInstalling Drasi...${RESET}"
 drasi init
 # This is a workaround for the issue with the init command regularly failing.
@@ -26,6 +27,7 @@ drasi init
 echo -e "${GREEN}\n\nUpdating Query Host to use In-memory Index...${RESET}"
 drasi apply -f examples/building_comfort/drasi/query_container_memory/query_container_memory.yaml
 drasi wait -f examples/building_comfort/drasi/query_container_memory/query_container_memory.yaml -t 200
+drasi delete querycontainer default
 
 # Deploy the Test Service and wait for it to be available
 echo -e "${GREEN}\n\nDeploying Test Service...${RESET}"

--- a/e2e-test-framework/examples/building_comfort/drasi/run_test_with_redis.sh
+++ b/e2e-test-framework/examples/building_comfort/drasi/run_test_with_redis.sh
@@ -17,15 +17,17 @@
 GREEN="\033[32m"
 RESET="\033[0m"
 
+drasi env kube
 echo -e "${GREEN}\n\nInstalling Drasi...${RESET}"
 drasi init
 # This is a workaround for the issue with the init command regularly failing.
-drasi init 
+drasi init
 
 # Update the Query Host to use Redis as the Index
 echo -e "${GREEN}\n\nUpdating Query Host to use Redis Index...${RESET}"
 drasi apply -f examples/building_comfort/drasi/query_container_redis/query_container_redis.yaml
 drasi wait -f examples/building_comfort/drasi/query_container_redis/query_container_redis.yaml -t 200
+drasi delete querycontainer default
 
 # Deploy the Test Service and wait for it to be available
 echo -e "${GREEN}\n\nDeploying Test Service...${RESET}"

--- a/e2e-test-framework/examples/building_comfort/drasi/run_test_with_rocks.sh
+++ b/e2e-test-framework/examples/building_comfort/drasi/run_test_with_rocks.sh
@@ -17,6 +17,7 @@
 GREEN="\033[32m"
 RESET="\033[0m"
 
+drasi env kube
 echo -e "${GREEN}\n\nInstalling Drasi...${RESET}"
 drasi init
 # This is a workaround for the issue with the init command regularly failing.
@@ -26,6 +27,7 @@ drasi init
 echo -e "${GREEN}\n\nUpdating Query Host to use a Rocks Index...${RESET}"
 drasi apply -f examples/building_comfort/drasi/query_container_rocks/query_container_rocks.yaml
 drasi wait -f examples/building_comfort/drasi/query_container_rocks/query_container_rocks.yaml -t 200
+drasi delete querycontainer default
 
 # Deploy the Test Service and wait for it to be available
 echo -e "${GREEN}\n\nDeploying Test Service...${RESET}"

--- a/e2e-test-framework/proxy/Cargo.toml
+++ b/e2e-test-framework/proxy/Cargo.toml
@@ -9,7 +9,7 @@ clap = { version = "4.3.21", features = ["derive", "env"] }
 futures = "0.3.3"
 log = "0.4"
 env_logger = "0.7.1"
-reqwest = { version = "0.12.7", features = ["json"] }
+reqwest = { version = "0.12.7", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/e2e-test-framework/proxy/Dockerfile
+++ b/e2e-test-framework/proxy/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.82 AS builder
-RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
+FROM rust:1.86 AS builder
+RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
 
 WORKDIR /usr/src
 COPY ./proxy ./proxy
@@ -21,10 +21,7 @@ COPY ./proxy ./proxy
 WORKDIR /usr/src/proxy
 RUN cargo install --force --path .
 
-FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y \
-    gdb curl wget vim net-tools iputils-ping \
-    && apt-get clean
-ENV RUST_BACKTRACE=1
+FROM gcr.io/distroless/cc
 COPY --from=builder /usr/local/cargo/bin/proxy /usr/local/bin/proxy
+USER root
 CMD ["proxy"]

--- a/e2e-test-framework/reactivator/Cargo.toml
+++ b/e2e-test-framework/reactivator/Cargo.toml
@@ -9,7 +9,7 @@ clap = { version = "4.3.21", features = ["derive", "env"] }
 futures = "0.3.3"
 log = "0.4"
 env_logger = "0.7.1"
-reqwest = { version = "0.12.7", features = ["json"] }
+reqwest = { version = "0.12.7", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/e2e-test-framework/reactivator/Dockerfile
+++ b/e2e-test-framework/reactivator/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.82 AS builder
-RUN apt-get update && apt-get install -y protobuf-compiler libcurl4 && apt-get clean
+FROM rust:1.86 AS builder
+RUN apt-get update && apt-get install -y protobuf-compiler cmake libc6-dev libssl-dev libclang-dev
 
 WORKDIR /usr/src
 COPY ./reactivator ./reactivator
@@ -21,10 +21,7 @@ COPY ./reactivator ./reactivator
 WORKDIR /usr/src/reactivator
 RUN cargo install --force --path .
 
-FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y \
-    gdb curl wget vim net-tools iputils-ping \
-    && apt-get clean
-ENV RUST_BACKTRACE=1
+FROM gcr.io/distroless/cc
 COPY --from=builder /usr/local/cargo/bin/reactivator /usr/local/bin/reactivator
+USER root
 CMD ["reactivator"]


### PR DESCRIPTION
This pull request updates the deployment scripts and Rust service configurations to improve security, reliability, and compatibility. The main changes include switching Docker base images to distroless for smaller and more secure containers, updating Rust dependencies to use `rustls-tls` for TLS support. This removes the dependency on system OpenSSL libraries, which elimiates the libssl.so.3 missing library error that we were seeing earlier. These changes follow the recent changes in the Rust dockerfiles on `drasi-platform`.

Additionally I have added some commands to the buildign comfort test script to improve the user experience