### PR TITLE
Feature lib

### DIFF
--- a/e2e-test-framework/.gitignore
+++ b/e2e-test-framework/.gitignore
@@ -2,3 +2,5 @@
 **/test_data_cache/
 
 *.log
+
+target/

--- a/e2e-test-framework/Cargo.toml
+++ b/e2e-test-framework/Cargo.toml
@@ -18,5 +18,18 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 
+[workspace.lints.rust]
+warnings = "deny"
+unused = "allow"
+
+[workspace.lints.clippy]
+print_stdout = "warn"
+unwrap_used = "warn"
+uninlined_format_args = "warn"
+module_inception = "allow"
+ptr_arg = "allow"
+type_complexity = "allow"
+large_enum_variant = "allow"
+
 [profile.release]
 lto = true

--- a/e2e-test-framework/data-collector/Cargo.toml
+++ b/e2e-test-framework/data-collector/Cargo.toml
@@ -24,3 +24,6 @@ thiserror = "1.0.63"
 async-trait = "0.1.81"
 walkdir = "2.5.0"
 uuid = { version = "1.2", features = ["v4"] }
+
+[lints]
+workspace = true

--- a/e2e-test-framework/infrastructure/comms-abstractions/Cargo.toml
+++ b/e2e-test-framework/infrastructure/comms-abstractions/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.80"
 serde_json = "1.0.117"
+
+[lints]
+workspace = true

--- a/e2e-test-framework/infrastructure/comms-dapr/Cargo.toml
+++ b/e2e-test-framework/infrastructure/comms-dapr/Cargo.toml
@@ -10,3 +10,6 @@ async-trait = "0.1.80"
 drasi-comms-abstractions = { path = "../comms-abstractions"}
 reqwest = { version = "0.11.24", features = ["blocking", "json"]}
 serde_json = "1.0.117"
+
+[lints]
+workspace = true

--- a/e2e-test-framework/proxy/Cargo.toml
+++ b/e2e-test-framework/proxy/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = "1.0.96"
 tokio = { version = "1.37.0", features = ["full"] }
 anyhow = "1.0.86"
 thiserror = "1.0.63"
+
+[lints]
+workspace = true

--- a/e2e-test-framework/reactivator/Cargo.toml
+++ b/e2e-test-framework/reactivator/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = "1.0.96"
 tokio = { version = "1.37.0", features = ["full"] }
 anyhow = "1.0.86"
 thiserror = "1.0.63"
+
+[lints]
+workspace = true

--- a/e2e-test-framework/test-data-store/Cargo.toml
+++ b/e2e-test-framework/test-data-store/Cargo.toml
@@ -24,3 +24,6 @@ anyhow = "1.0.86"
 thiserror = "1.0.63"
 async-trait = "0.1.81"
 walkdir = "2.5.0"
+
+[lints]
+workspace = true

--- a/e2e-test-framework/test-run-host/Cargo.toml
+++ b/e2e-test-framework/test-run-host/Cargo.toml
@@ -57,3 +57,6 @@ opentelemetry-otlp = { version = "0.13", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.20", features = ["rt-tokio", "metrics", "trace"] }
 opentelemetry-semantic-conventions = "0.12"
 portpicker = "0.1"
+
+[lints]
+workspace = true

--- a/e2e-test-framework/test-service/Cargo.toml
+++ b/e2e-test-framework/test-service/Cargo.toml
@@ -36,3 +36,6 @@ tempfile = "3.20.0"
 nix = { version = "0.29", features = ["signal"] }
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.37.0", features = ["full", "test-util"] }
+
+[lints]
+workspace = true


### PR DESCRIPTION
This pull request introduces workspace-wide linting policies and applies them to all Rust crates in the `e2e-test-framework` project. It also updates the `.gitignore` to exclude build artifacts and updates a submodule reference. These changes help ensure consistent code quality and simplify lint management across the workspace.

Workspace linting improvements:

* Added `[workspace.lints.rust]` and `[workspace.lints.clippy]` sections to the root `Cargo.toml` to define linting rules for the entire workspace, enforcing stricter warnings and customizing Clippy lint levels.
* Updated all crate-level `Cargo.toml` files to inherit lint settings from the workspace by adding `[lints] workspace = true`. [[1]](diffhunk://#diff-7cdcaaa87f12a960811314a86d87b2e49d956d9f76e9da543463843afe435045R27-R29) [[2]](diffhunk://#diff-f8182c17a5656d06bf08bc0099a6f55defcdf5b0c26317f2bcb97f4a54311f63R11-R13) [[3]](diffhunk://#diff-77ae7999a0cff593eb8cd6996d7e760d9887b30cb4f1d1d4ff7b8f3d6412b732R13-R15) [[4]](diffhunk://#diff-a6e3ad632eb95f3b7529b7d94c3d2ee1cab5b927a2270c3d68e1758cb834c752R18-R20) [[5]](diffhunk://#diff-71b50d347a7401c5f9976306537ef24bf0f7cbedc028185d641debd4dc3f9463R18-R20) [[6]](diffhunk://#diff-e0cd490dcfd394b75d0d53e8e6459c2e2523b3b2fb677f30875760d59e53303aR27-R29) [[7]](diffhunk://#diff-79029869dbb6408d4036521084b6cc4eb543e2f6fa90487fedc726a443e7886cR60-R62) [[8]](diffhunk://#diff-36dfa42a9398aa958722696e479eb71f7d461d1a639bfa632741895b6d743605R39-R41)

Repository maintenance:

* Updated `.gitignore` to exclude the `target/` directory, preventing build artifacts from being committed.
* Updated the `drasi-core` submodule reference in `test-run-host` to a new commit.