### PR TITLE
ARN and Redis CLI Data Tools

### DIFF
--- a/data-tools/arn/Cargo.toml
+++ b/data-tools/arn/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "arn"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+test-data-store = { path = "../../e2e-test-framework/test-data-store" }
+
+anyhow = "1.0.86"
+chrono = { version = "0.4.38", features = ["serde"] }
+clap = { version = "4.5.18", features = ["derive", "env"] }
+env_logger = "0.7.1"
+log = "0.4"
+rand = "0.8.5"
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.96"
+strum = "0.26.3"
+strum_macros = "0.26.4"
+tokio = { version = "1.37.0", features = ["full"] }
+uuid = { version = "1.10.0", features = ["v4", "serde"] }

--- a/data-tools/arn/README.md
+++ b/data-tools/arn/README.md
@@ -1,0 +1,297 @@
+# ARN Test Data Generator
+
+A Rust CLI tool for generating fictional Azure Resource Notification (ARN) test data for Drasi testing. This tool creates realistic ARN Schema V3 compliant data including Management Groups, Service Groups, and their relationships.
+
+## Overview
+
+The ARN data generator creates two types of output files:
+- **Bootstrap scripts**: Initial data snapshot with all resources
+- **Source change scripts**: Debezium-style change events (inserts and updates)
+
+## Installation
+
+Build the tool from the `data-tools/arn` directory:
+
+```bash
+cd data-tools/arn
+cargo build --release
+```
+
+## Usage
+
+### Basic Command
+
+```bash
+cargo run -- generate -i <test-id> [OPTIONS]
+```
+
+### Command-Line Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--test-id` | `-i` | Test identifier (required) | - |
+| `--source-id` | `-d` | Source identifier | `arn-events` |
+| `--management-group-count` | `-m` | Number of management groups | `10` |
+| `--service-group-count` | `-g` | Number of service groups | `5` |
+| `--relationship-count` | `-r` | Number of relationships | `20` |
+| `--hierarchy-depth` | `-p` | Management group hierarchy depth | `4` |
+| `--start-time` | `-s` | Start timestamp (YYYY-MM-DD HH:MM:SS) | Current time |
+| `--change-count` | `-c` | Number of change events | `50` |
+| `--change-duration-secs` | `-u` | Duration for changes (seconds) | `3600` |
+| `--tenant-id` | `-t` | Azure tenant ID (optional) | Generated UUID |
+| `--notification-format` | `-f` | Notification format (see below) | `full-payload` |
+| `--batch-size` | `-b` | Resources per batch (for batched formats) | `3` |
+| `--subscription-id` | | Azure subscription ID (for batched) | Generated UUID |
+
+#### Notification Formats
+
+The tool supports four different Event Grid notification formats:
+
+1. **`full-payload`** - Single resource per notification with complete ARM payload
+   - One Event Grid event per resource
+   - Includes full `armResource` object with all properties
+   - Best for: Testing individual resource notifications
+
+2. **`payload-less`** - Single resource per notification with resourceId only
+   - One Event Grid event per resource
+   - Only includes `resourceId` and `correlationId`
+   - ARG must make GET calls to fetch resource details
+   - Best for: Testing resource lookup scenarios
+
+3. **`batched-ids`** - Multiple resources per notification with resourceId only
+   - Multiple resources grouped in single Event Grid event
+   - Only includes `resourceId` and `correlationId` for each
+   - Subject is subscription-level (not resource-level)
+   - Best for: Testing high-volume batch scenarios with lookups
+
+4. **`batched-payloads`** - Multiple resources per notification with full payloads
+   - Multiple resources grouped in single Event Grid event
+   - Includes full `armResource` object for each resource
+   - Subject is subscription-level (not resource-level)
+   - Best for: Testing high-volume batch scenarios without lookups
+
+### Examples
+
+#### Generate Small Test Dataset (Default Full Payload Format)
+
+```bash
+cargo run -- generate -i my-test -m 3 -g 2 -r 5 -p 2
+```
+
+This creates:
+- 3 management groups in 2-level hierarchy
+- 2 service groups
+- 5 relationships between them
+- 50 change events (default)
+- Event Grid events with full ARM payloads
+
+#### Generate Payload-Less Notifications
+
+```bash
+cargo run -- generate -i payloadless-test -m 10 -f payload-less
+```
+
+This creates notifications with only `resourceId` and `correlationId`, requiring ARG to fetch resource details.
+
+#### Generate Batched Notifications (IDs only)
+
+```bash
+cargo run -- generate -i batch-ids-test -m 20 -f batched-ids -b 5
+```
+
+This creates:
+- 20 management groups batched into groups of 5
+- Each Event Grid event contains 5 resources (resourceId only)
+- Subject is at subscription level
+
+#### Generate Batched Notifications (Full Payloads)
+
+```bash
+cargo run -- generate -i batch-full-test -m 20 -f batched-payloads -b 5
+```
+
+This creates:
+- 20 management groups batched into groups of 5
+- Each Event Grid event contains 5 resources with full ARM payloads
+- Subject is at subscription level
+
+#### Generate Large Dataset with Custom Parameters
+
+```bash
+cargo run -- generate \
+  -i large-test \
+  -m 20 \
+  -g 10 \
+  -r 50 \
+  -p 5 \
+  -c 100 \
+  -u 7200 \
+  -t "12345678-1234-1234-1234-123456789012"
+```
+
+This creates:
+- 20 management groups in 5-level hierarchy
+- 10 service groups
+- 50 relationships
+- 100 change events over 2 hours
+- Uses specified tenant ID
+
+#### Specify Custom Start Time
+
+```bash
+cargo run -- generate \
+  -i time-test \
+  -s "2024-01-01 00:00:00" \
+  -m 5 \
+  -g 3 \
+  -r 10
+```
+
+## Event Grid Event Structure
+
+All generated data is wrapped in Azure Event Grid event envelopes with the following structure:
+
+```json
+{
+  "topic": "custom-domain-topic/eg-topic",
+  "subject": "<resource-id or subscription-id>",
+  "eventType": "Microsoft.Management/managementGroups/write",
+  "eventTime": "2025-12-19T22:29:50.335102+00:00",
+  "id": "<unique-event-id>",
+  "data": {
+    "resourceLocation": "global",
+    "publisherInfo": "Microsoft.Resources",
+    "apiVersion": "2020-03-01-preview",
+    "resources": [
+      {
+        "resourceId": "/providers/Microsoft.Management/managementGroups/<id>",
+        "correlationId": "<unique-correlation-id>",
+        "apiVersion": "2021-04-01",
+        "armResource": { /* Full ARM resource object */ },
+        "resourceSystemProperties": { /* System metadata */ }
+      }
+    ]
+  },
+  "dataVersion": "3.0",
+  "metadataVersion": "1"
+}
+```
+
+**Key differences by format:**
+- **full-payload**: `subject` is resource-level, `armResource` is populated
+- **payload-less**: `subject` is resource-level, only `resourceId` and `correlationId` present
+- **batched-ids**: `subject` is subscription-level, multiple resources with `resourceId` only
+- **batched-payloads**: `subject` is subscription-level, multiple resources with full `armResource`
+
+## Output Structure
+
+Generated files are placed in `./arn_data/scripts/<test-id>/sources/<source-id>/`:
+
+```
+arn_data/
+└── scripts/
+    └── <test-id>/
+        └── sources/
+            └── <source-id>/
+                ├── bootstrap_scripts/
+                │   └── arn_resources/
+                │       └── arn_resources_00000.jsonl
+                └── source_change_scripts/
+                    └── source_change_scripts_00000.jsonl
+```
+
+### Bootstrap Script Format
+
+The bootstrap script contains a header followed by Node records for all resources:
+
+```json
+{"kind":"Header","start_time":"2025-11-17T21:23:49.765379Z","description":"Drasi Bootstrap Data Script for TestID test-bootstrap, SourceID: arn-events"}
+{"kind":"Node","id":"/providers/Microsoft.Management/managementGroups/mg-root-...","labels":["ManagementGroup"],"properties":{...}}
+{"kind":"Node","id":"/providers/Microsoft.Management/serviceGroups/sg-...","labels":["ServiceGroup"],"properties":{...}}
+{"kind":"Node","id":"/providers/microsoft.relationships/servicegroupmembers/rel-...","labels":["Relationship","ServiceGroupMember"],"properties":{...}}
+```
+
+### Source Change Script Format
+
+The source change script contains Debezium-style change events:
+
+```json
+{"kind":"Header","start_time":"2025-11-17T21:23:49.765379Z","description":"Drasi Source Change Data Script for TestID test-bootstrap, SourceID: arn-events"}
+{"kind":"SourceChange","offset_ns":1000000000,"source_change_event":{"op":"i","reactivator_start_ns":0,"reactivator_end_ns":0,"payload":{"source":{"db":"arn-events","table":"node","ts_ns":1731878629765379000,"lsn":1},"before":null,"after":{...}}}}
+{"kind":"SourceChange","offset_ns":2000000000,"source_change_event":{"op":"u","reactivator_start_ns":0,"reactivator_end_ns":0,"payload":{"source":{...},"before":{...},"after":{...}}}}
+```
+
+## Generated Resource Types
+
+### Management Groups
+- Hierarchical structure with configurable depth
+- Azure resource ID format: `/providers/Microsoft.Management/managementGroups/<id>`
+- Properties include display name, tenant ID, parent relationships
+
+### Service Groups
+- Service-specific groups (Compute, Storage, Networking, Database)
+- Azure resource ID format: `/providers/Microsoft.Management/serviceGroups/<id>`
+- Properties include display name, description, tenant ID
+
+### Relationships
+- ServiceGroupMember relationships linking management groups to service groups
+- Azure resource ID format: `/providers/microsoft.relationships/servicegroupmembers/<id>`
+- Properties include SourceId and TargetId references
+
+## ARN Schema V3 Compliance
+
+All generated resources follow ARN Schema V3 structure:
+- `homeTenantId` and `resourceHomeTenantId`
+- `resourcesContainer: "Inline"`
+- `resourceLocation: "global"`
+- `publisherInfo: "Microsoft.Management"`
+- `apiVersion: "2021-04-01"`
+- `armResource` with full resource details
+- `resourceSystemProperties` with changeAction, createdBy, createdTime
+- Correlation IDs for event tracking
+
+## Use Cases
+
+### Drasi Testing
+Use the generated data to test Drasi continuous queries:
+
+1. Load bootstrap data to initialize the system
+2. Apply source change scripts to simulate data changes
+3. Verify query results and reactions
+
+### Integration Testing
+- Test multi-source data integration scenarios
+- Validate graph query patterns across resources
+- Test change detection and reaction pipelines
+
+### Performance Testing
+Generate large datasets to test system performance:
+
+```bash
+cargo run -- generate -i perf-test -m 100 -g 50 -r 500 -c 1000
+```
+
+## Notes
+
+- All timestamps are in UTC
+- Resource IDs are generated with unique suffixes
+- Tenant IDs are consistent across all resources in a single generation
+- Change events include both inserts (new resources) and updates (modified resources)
+- The tool uses randomization for realistic variety in display names, creators, and timing
+
+## Troubleshooting
+
+### Build Warnings
+The tool may show unused import warnings during build. These are non-critical and don't affect functionality.
+
+### File Permissions
+Ensure the `arn_data` directory has write permissions. The tool will create the directory structure if it doesn't exist.
+
+### Invalid Timestamps
+If providing a custom start time with `-s`, use the format: `YYYY-MM-DD HH:MM:SS`
+
+## Related Documentation
+
+- [ARN Summary](summary.md) - Detailed ARN schema and architecture
+- [CLAUDE.md](CLAUDE.md) - ARN data generator specification
+- [Drasi Documentation](https://drasi.io) - Drasi platform documentation

--- a/data-tools/arn/src/arn/generator.rs
+++ b/data-tools/arn/src/arn/generator.rs
@@ -1,0 +1,293 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::{DateTime, Duration, Utc};
+use rand::seq::SliceRandom;
+use rand::Rng;
+use uuid::Uuid;
+
+use super::models::{ManagementGroupResource, RelationshipResource, ServiceGroupResource};
+
+pub struct GeneratorConfig {
+    pub tenant_id: String,
+    pub management_group_count: usize,
+    pub service_group_count: usize,
+    pub relationship_count: usize,
+    pub hierarchy_depth: usize,
+    pub start_time: DateTime<Utc>,
+}
+
+pub struct ArnDataGenerator {
+    config: GeneratorConfig,
+    rng: rand::rngs::ThreadRng,
+}
+
+impl ArnDataGenerator {
+    pub fn new(config: GeneratorConfig) -> Self {
+        Self {
+            config,
+            rng: rand::thread_rng(),
+        }
+    }
+
+    /// Generate a set of Management Groups with hierarchical relationships
+    pub fn generate_management_groups(&mut self) -> Vec<ManagementGroupResource> {
+        let mut management_groups = Vec::new();
+        let users = vec![
+            "admin@contoso.com",
+            "user@contoso.com",
+            "sysadmin@contoso.com",
+        ];
+
+        // Create root management group
+        let root_id = format!("mg-root-{}", Uuid::new_v4().to_string()[..8].to_string());
+        let root_mg = ManagementGroupResource::new(
+            root_id.clone(),
+            root_id.clone(),
+            "Root Management Group".to_string(),
+            self.config.tenant_id.clone(),
+            None,
+            self.config.start_time,
+            users.choose(&mut self.rng).unwrap().to_string(),
+        );
+        management_groups.push(root_mg);
+
+        // Generate hierarchical management groups
+        let mut current_level_groups = vec![root_id.clone()];
+        let mut groups_per_level = vec![1];
+
+        // Calculate how many groups to create per level
+        let remaining_groups = self.config.management_group_count - 1;
+        let levels = self.config.hierarchy_depth.min(remaining_groups);
+
+        if levels > 0 {
+            let groups_per_remaining_level = remaining_groups / levels;
+            for _ in 0..levels {
+                groups_per_level.push(groups_per_remaining_level);
+            }
+        }
+
+        // Generate groups level by level
+        let mut created_count = 1;
+        for (level, &count) in groups_per_level.iter().enumerate().skip(1) {
+            if created_count >= self.config.management_group_count {
+                break;
+            }
+
+            let mut next_level_groups = Vec::new();
+
+            for i in 0..count {
+                if created_count >= self.config.management_group_count {
+                    break;
+                }
+
+                // Pick a random parent from the current level
+                let parent_id = current_level_groups
+                    .choose(&mut self.rng)
+                    .unwrap()
+                    .clone();
+
+                let mg_id = format!("mg-l{}-{:03}", level, i);
+                let mg_name = format!("Management Group L{} #{}", level, i + 1);
+
+                let time_offset = Duration::seconds(created_count as i64 * 60);
+                let mg = ManagementGroupResource::new(
+                    mg_id.clone(),
+                    mg_id.clone(),
+                    mg_name,
+                    self.config.tenant_id.clone(),
+                    Some(parent_id),
+                    self.config.start_time + time_offset,
+                    users.choose(&mut self.rng).unwrap().to_string(),
+                );
+
+                management_groups.push(mg);
+                next_level_groups.push(mg_id);
+                created_count += 1;
+            }
+
+            current_level_groups = next_level_groups;
+        }
+
+        management_groups
+    }
+
+    /// Generate Service Groups
+    pub fn generate_service_groups(&mut self) -> Vec<ServiceGroupResource> {
+        let mut service_groups = Vec::new();
+        let users = vec![
+            "admin@contoso.com",
+            "user@contoso.com",
+            "sysadmin@contoso.com",
+        ];
+        let service_types = vec![
+            "Compute",
+            "Storage",
+            "Networking",
+            "Database",
+            "Security",
+            "Analytics",
+            "AI/ML",
+        ];
+
+        for i in 0..self.config.service_group_count {
+            let sg_id = format!("sg-{:03}", i);
+            let service_type = service_types.choose(&mut self.rng).unwrap();
+            let sg_name = format!("{} Service Group {}", service_type, i + 1);
+            let description = format!("Service group for {} resources", service_type);
+
+            let time_offset = Duration::seconds((i * 120) as i64);
+            let sg = ServiceGroupResource::new(
+                sg_id.clone(),
+                sg_id,
+                sg_name,
+                description,
+                self.config.tenant_id.clone(),
+                self.config.start_time + time_offset,
+                users.choose(&mut self.rng).unwrap().to_string(),
+            );
+
+            service_groups.push(sg);
+        }
+
+        service_groups
+    }
+
+    /// Generate Relationship Resources (Service Group Members)
+    pub fn generate_relationships(
+        &mut self,
+        management_groups: &[ManagementGroupResource],
+        service_groups: &[ServiceGroupResource],
+    ) -> Vec<RelationshipResource> {
+        let mut relationships = Vec::new();
+        let users = vec![
+            "admin@contoso.com",
+            "user@contoso.com",
+            "sysadmin@contoso.com",
+        ];
+
+        for i in 0..self.config.relationship_count {
+            // Pick random source (management group) and target (service group)
+            let source_mg = management_groups.choose(&mut self.rng).unwrap();
+            let target_sg = service_groups.choose(&mut self.rng).unwrap();
+
+            let rel_id = format!("rel-{:04}", i);
+            let source_id = format!(
+                "/providers/Microsoft.Management/managementGroups/{}",
+                source_mg.id
+            );
+            let target_id = format!(
+                "/providers/Microsoft.Management/serviceGroups/{}",
+                target_sg.id
+            );
+
+            let time_offset = Duration::seconds((i * 90) as i64);
+            let rel = RelationshipResource::new(
+                rel_id.clone(),
+                rel_id,
+                source_id,
+                target_id,
+                self.config.tenant_id.clone(),
+                self.config.start_time + time_offset,
+                users.choose(&mut self.rng).unwrap().to_string(),
+            );
+
+            relationships.push(rel);
+        }
+
+        relationships
+    }
+
+    /// Generate change events (updates and inserts)
+    pub fn generate_change_events(
+        &mut self,
+        management_groups: &[ManagementGroupResource],
+        _service_groups: &[ServiceGroupResource],
+        change_count: usize,
+        duration_secs: u64,
+    ) -> Vec<ChangeEvent> {
+        let mut events = Vec::new();
+        let users = vec![
+            "admin@contoso.com",
+            "user@contoso.com",
+            "operator@contoso.com",
+        ];
+
+        let interval_secs = if change_count > 0 {
+            duration_secs / change_count as u64
+        } else {
+            1
+        };
+
+        for i in 0..change_count {
+            let time_offset = Duration::seconds((i as u64 * interval_secs) as i64);
+            let event_time = self.config.start_time + time_offset;
+
+            // 70% updates, 30% inserts
+            let is_update = self.rng.gen_bool(0.7);
+
+            if is_update && !management_groups.is_empty() {
+                // Generate an update event for an existing management group
+                let mg = management_groups.choose(&mut self.rng).unwrap();
+                let new_display_name = format!("{} - Updated", mg.display_name);
+                let updated_by = users.choose(&mut self.rng).unwrap().to_string();
+
+                events.push(ChangeEvent::Update {
+                    management_group: mg.clone(),
+                    new_display_name,
+                    updated_at: event_time,
+                    updated_by,
+                });
+            } else {
+                // Generate an insert event for a new management group
+                let mg_id = format!("mg-new-{:04}", i);
+                let mg_name = format!("New Management Group {}", i + 1);
+
+                // Pick a random parent from existing groups
+                let parent_id = if !management_groups.is_empty() && self.rng.gen_bool(0.8) {
+                    Some(management_groups.choose(&mut self.rng).unwrap().id.clone())
+                } else {
+                    None
+                };
+
+                let mg = ManagementGroupResource::new(
+                    mg_id.clone(),
+                    mg_id,
+                    mg_name,
+                    self.config.tenant_id.clone(),
+                    parent_id,
+                    event_time,
+                    users.choose(&mut self.rng).unwrap().to_string(),
+                );
+
+                events.push(ChangeEvent::Insert { management_group: mg });
+            }
+        }
+
+        events
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ChangeEvent {
+    Insert {
+        management_group: ManagementGroupResource,
+    },
+    Update {
+        management_group: ManagementGroupResource,
+        new_display_name: String,
+        updated_at: DateTime<Utc>,
+        updated_by: String,
+    },
+}

--- a/data-tools/arn/src/arn/mod.rs
+++ b/data-tools/arn/src/arn/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod generator;
+pub mod models;
+
+pub use generator::{ArnDataGenerator, GeneratorConfig};
+pub use models::{
+    ArnNotificationData, ArnResource, ArnResourcesData, EventGridEvent, ManagementGroupResource,
+    NotificationFormat, RelationshipResource, ResourceType, ServiceGroupResource,
+    create_batched_event_grid_event,
+};

--- a/data-tools/arn/src/arn/models.rs
+++ b/data-tools/arn/src/arn/models.rs
@@ -1,0 +1,728 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::{DateTime, Utc};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+/// Generate a random publisher info (70% Microsoft.Resources, 30% Default)
+fn random_publisher_info() -> String {
+    let mut rng = rand::thread_rng();
+    if rng.gen_bool(0.7) {
+        "Microsoft.Resources".to_string()
+    } else {
+        "Default".to_string()
+    }
+}
+
+/// Notification format types
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum NotificationFormat {
+    /// Single resource with full ARM payload
+    FullPayload,
+    /// Single resource with resourceId only (no payload)
+    PayloadLess,
+    /// Multiple resources with resourceId only (batched)
+    BatchedIds,
+    /// Multiple resources with full ARM payload (batched)
+    BatchedPayloads,
+}
+
+/// Event Grid event envelope wrapper
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventGridEvent {
+    /// Event Grid topic
+    pub topic: String,
+    /// Resource subject (typically resource ID or subscription)
+    pub subject: String,
+    /// Event type
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+    /// Event timestamp
+    #[serde(rename = "eventTime")]
+    pub event_time: String,
+    /// Unique event ID
+    pub id: String,
+    /// ARN notification data
+    pub data: ArnNotificationData,
+    /// Data version (3.0 for ARN v3)
+    #[serde(rename = "dataVersion")]
+    pub data_version: String,
+    /// Metadata version
+    #[serde(rename = "metadataVersion")]
+    pub metadata_version: String,
+}
+
+/// ARN notification data (inside Event Grid event.data)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArnNotificationData {
+    /// Resource location
+    pub resource_location: String,
+    /// Publisher info
+    pub publisher_info: String,
+    /// API version (at data level for batched notifications)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+    /// Resources array
+    pub resources: Vec<ArnResourcesData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ResourceType {
+    ManagementGroup,
+    ServiceGroup,
+    Relationship,
+}
+
+impl ResourceType {
+    pub fn as_label(&self) -> &str {
+        match self {
+            ResourceType::ManagementGroup => "ManagementGroup",
+            ResourceType::ServiceGroup => "ServiceGroup",
+            ResourceType::Relationship => "Relationship",
+        }
+    }
+
+    pub fn as_arm_type(&self) -> &str {
+        match self {
+            ResourceType::ManagementGroup => "Microsoft.Management/managementGroups",
+            ResourceType::ServiceGroup => "Microsoft.Management/serviceGroups",
+            ResourceType::Relationship => "microsoft.relationships/servicegroupmember",
+        }
+    }
+}
+
+/// Base ARN Resource structure that maps to Drasi Node format
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArnResource {
+    pub id: String,
+    pub labels: Vec<String>,
+    pub properties: ArnResourceProperties,
+}
+
+impl ArnResource {
+    pub fn new(
+        resource_id: String,
+        resource_type: ResourceType,
+        properties: ArnResourceProperties,
+    ) -> Self {
+        let labels = match resource_type {
+            ResourceType::ManagementGroup => vec!["ManagementGroup".to_string()],
+            ResourceType::ServiceGroup => vec!["ServiceGroup".to_string()],
+            ResourceType::Relationship => {
+                vec!["Relationship".to_string(), "ServiceGroupMember".to_string()]
+            }
+        };
+
+        Self {
+            id: resource_id,
+            labels,
+            properties,
+        }
+    }
+}
+
+/// ARN Resource Properties (notification level properties)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArnResourceProperties {
+    /// Tenant from which the resource is managed (notification level)
+    pub home_tenant_id: String,
+    /// Tenant in which the resource exists (notification level)
+    pub resource_home_tenant_id: String,
+    /// Inline or Blob
+    pub resources_container: String,
+    /// Resource location
+    pub resource_location: String,
+    /// Publisher info: Microsoft.Resources or Default
+    pub publisher_info: String,
+    /// For inline payload, resources is a list containing ArnResourcesData
+    pub resources: Vec<ArnResourcesData>,
+}
+
+/// Individual resource data within the resources array (NotificationResourceData)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArnResourcesData {
+    /// Resource identifier in ARM format (REQUIRED)
+    pub resource_id: String,
+    /// Correlation id for tracking (REQUIRED)
+    pub correlation_id: String,
+    /// Populated for resource moves - the source resource identifier
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_resource_id: Option<String>,
+    /// Version of the resource schema (optional for payload-less)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+    /// When the activity for this resource occurred
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_event_time: Option<String>,
+    /// Tenant from which the resource is managed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub home_tenant_id: Option<String>,
+    /// Tenant in which the resource exists
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_home_tenant_id: Option<String>,
+    /// HTTP status code for the operation (OK, BadRequest, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<String>,
+    /// Resource payload (armResource) - optional for payload-less format
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arm_resource: Option<Value>,
+    /// System properties for the resource
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_system_properties: Option<ResourceSystemProperties>,
+    /// Additional metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_resource_properties: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSystemProperties {
+    pub created_by: String,
+    pub created_time: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_modified_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_modified_time: Option<String>,
+    pub change_action: String,
+}
+
+/// Management Group Resource
+#[derive(Debug, Clone)]
+pub struct ManagementGroupResource {
+    pub id: String,
+    pub name: String,
+    pub display_name: String,
+    pub tenant_id: String,
+    pub parent_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub created_by: String,
+}
+
+impl ManagementGroupResource {
+    pub fn new(
+        id: String,
+        name: String,
+        display_name: String,
+        tenant_id: String,
+        parent_id: Option<String>,
+        created_at: DateTime<Utc>,
+        created_by: String,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            display_name,
+            tenant_id,
+            parent_id,
+            created_at,
+            created_by,
+        }
+    }
+
+    pub fn to_arn_resource(&self, change_action: &str) -> ArnResource {
+        let resource_id = format!("/providers/Microsoft.Management/managementGroups/{}", self.id);
+        let correlation_id = Uuid::new_v4().to_string();
+
+        let parent_value = match &self.parent_id {
+            Some(parent_id) => json!({
+                "id": format!("/providers/Microsoft.Management/managementGroups/{}", parent_id)
+            }),
+            None => Value::Null,
+        };
+
+        let arm_resource = json!({
+            "id": resource_id,
+            "name": self.name,
+            "type": "Microsoft.Management/managementGroups",
+            "properties": {
+                "displayName": self.display_name,
+                "tenantId": self.tenant_id,
+                "details": {
+                    "parent": parent_value
+                }
+            }
+        });
+
+        let resource_data = ArnResourcesData {
+            resource_id: resource_id.clone(),
+            source_resource_id: None,
+            api_version: Some("2021-04-01".to_string()),
+            correlation_id,
+            resource_event_time: Some(self.created_at.to_rfc3339()),
+            home_tenant_id: Some(self.tenant_id.clone()),
+            resource_home_tenant_id: Some(self.tenant_id.clone()),
+            status_code: Some("OK".to_string()),
+            arm_resource: Some(arm_resource),
+            resource_system_properties: Some(ResourceSystemProperties {
+                created_by: self.created_by.clone(),
+                created_time: self.created_at.to_rfc3339(),
+                last_modified_by: None,
+                last_modified_time: None,
+                change_action: change_action.to_string(),
+            }),
+            additional_resource_properties: None,
+        };
+
+        let properties = ArnResourceProperties {
+            home_tenant_id: self.tenant_id.clone(),
+            resource_home_tenant_id: self.tenant_id.clone(),
+            resources_container: "Inline".to_string(),
+            resource_location: "global".to_string(),
+            publisher_info: random_publisher_info(),
+            resources: vec![resource_data],
+        };
+
+        ArnResource::new(resource_id, ResourceType::ManagementGroup, properties)
+    }
+
+    pub fn to_updated_arn_resource(
+        &self,
+        new_display_name: String,
+        updated_at: DateTime<Utc>,
+        updated_by: String,
+    ) -> ArnResource {
+        let resource_id = format!("/providers/Microsoft.Management/managementGroups/{}", self.id);
+        let correlation_id = Uuid::new_v4().to_string();
+
+        let parent_value = match &self.parent_id {
+            Some(parent_id) => json!({
+                "id": format!("/providers/Microsoft.Management/managementGroups/{}", parent_id)
+            }),
+            None => Value::Null,
+        };
+
+        let arm_resource = json!({
+            "id": resource_id,
+            "name": self.name,
+            "type": "Microsoft.Management/managementGroups",
+            "properties": {
+                "displayName": new_display_name,
+                "tenantId": self.tenant_id,
+                "details": {
+                    "parent": parent_value
+                }
+            }
+        });
+
+        let resource_data = ArnResourcesData {
+            resource_id: resource_id.clone(),
+            source_resource_id: None,
+            api_version: Some("2021-04-01".to_string()),
+            correlation_id,
+            resource_event_time: Some(updated_at.to_rfc3339()),
+            home_tenant_id: Some(self.tenant_id.clone()),
+            resource_home_tenant_id: Some(self.tenant_id.clone()),
+            status_code: Some("OK".to_string()),
+            arm_resource: Some(arm_resource),
+            resource_system_properties: Some(ResourceSystemProperties {
+                created_by: self.created_by.clone(),
+                created_time: self.created_at.to_rfc3339(),
+                last_modified_by: Some(updated_by),
+                last_modified_time: Some(updated_at.to_rfc3339()),
+                change_action: "Update".to_string(),
+            }),
+            additional_resource_properties: None,
+        };
+
+        let properties = ArnResourceProperties {
+            home_tenant_id: self.tenant_id.clone(),
+            resource_home_tenant_id: self.tenant_id.clone(),
+            resources_container: "Inline".to_string(),
+            resource_location: "global".to_string(),
+            publisher_info: random_publisher_info(),
+            resources: vec![resource_data],
+        };
+
+        ArnResource::new(resource_id, ResourceType::ManagementGroup, properties)
+    }
+}
+
+/// Service Group Resource
+#[derive(Debug, Clone)]
+pub struct ServiceGroupResource {
+    pub id: String,
+    pub name: String,
+    pub display_name: String,
+    pub description: String,
+    pub tenant_id: String,
+    pub created_at: DateTime<Utc>,
+    pub created_by: String,
+}
+
+impl ServiceGroupResource {
+    pub fn new(
+        id: String,
+        name: String,
+        display_name: String,
+        description: String,
+        tenant_id: String,
+        created_at: DateTime<Utc>,
+        created_by: String,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            display_name,
+            description,
+            tenant_id,
+            created_at,
+            created_by,
+        }
+    }
+
+    pub fn to_arn_resource(&self, change_action: &str) -> ArnResource {
+        let resource_id = format!("/providers/Microsoft.Management/serviceGroups/{}", self.id);
+        let correlation_id = Uuid::new_v4().to_string();
+
+        let arm_resource = json!({
+            "id": resource_id,
+            "name": self.name,
+            "type": "Microsoft.Management/serviceGroups",
+            "properties": {
+                "displayName": self.display_name,
+                "description": self.description,
+                "tenantId": self.tenant_id,
+            }
+        });
+
+        let resource_data = ArnResourcesData {
+            resource_id: resource_id.clone(),
+            source_resource_id: None,
+            api_version: Some("2021-04-01".to_string()),
+            correlation_id,
+            resource_event_time: Some(self.created_at.to_rfc3339()),
+            home_tenant_id: Some(self.tenant_id.clone()),
+            resource_home_tenant_id: Some(self.tenant_id.clone()),
+            status_code: Some("OK".to_string()),
+            arm_resource: Some(arm_resource),
+            resource_system_properties: Some(ResourceSystemProperties {
+                created_by: self.created_by.clone(),
+                created_time: self.created_at.to_rfc3339(),
+                last_modified_by: None,
+                last_modified_time: None,
+                change_action: change_action.to_string(),
+            }),
+            additional_resource_properties: None,
+        };
+
+        let properties = ArnResourceProperties {
+            home_tenant_id: self.tenant_id.clone(),
+            resource_home_tenant_id: self.tenant_id.clone(),
+            resources_container: "Inline".to_string(),
+            resource_location: "global".to_string(),
+            publisher_info: random_publisher_info(),
+            resources: vec![resource_data],
+        };
+
+        ArnResource::new(resource_id, ResourceType::ServiceGroup, properties)
+    }
+}
+
+/// Relationship Resource (Service Group Member)
+#[derive(Debug, Clone)]
+pub struct RelationshipResource {
+    pub id: String,
+    pub name: String,
+    pub source_id: String,
+    pub target_id: String,
+    pub relationship_type: String,
+    pub tenant_id: String,
+    pub created_at: DateTime<Utc>,
+    pub created_by: String,
+}
+
+impl RelationshipResource {
+    pub fn new(
+        id: String,
+        name: String,
+        source_id: String,
+        target_id: String,
+        tenant_id: String,
+        created_at: DateTime<Utc>,
+        created_by: String,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            source_id,
+            target_id,
+            relationship_type: "ServiceGroupMember".to_string(),
+            tenant_id,
+            created_at,
+            created_by,
+        }
+    }
+
+    pub fn to_arn_resource(&self, change_action: &str) -> ArnResource {
+        let resource_id = format!(
+            "/providers/microsoft.relationships/servicegroupmembers/{}",
+            self.id
+        );
+        let correlation_id = Uuid::new_v4().to_string();
+
+        let arm_resource = json!({
+            "id": resource_id,
+            "name": self.name,
+            "type": "microsoft.relationships/servicegroupmember",
+            "properties": {
+                "SourceId": self.source_id,
+                "TargetId": self.target_id,
+                "RelationshipType": self.relationship_type,
+                "tenantId": self.tenant_id,
+            }
+        });
+
+        let resource_data = ArnResourcesData {
+            resource_id: resource_id.clone(),
+            source_resource_id: None,
+            api_version: Some("2021-04-01".to_string()),
+            correlation_id,
+            resource_event_time: Some(self.created_at.to_rfc3339()),
+            home_tenant_id: Some(self.tenant_id.clone()),
+            resource_home_tenant_id: Some(self.tenant_id.clone()),
+            status_code: Some("OK".to_string()),
+            arm_resource: Some(arm_resource),
+            resource_system_properties: Some(ResourceSystemProperties {
+                created_by: self.created_by.clone(),
+                created_time: self.created_at.to_rfc3339(),
+                last_modified_by: None,
+                last_modified_time: None,
+                change_action: change_action.to_string(),
+            }),
+            additional_resource_properties: None,
+        };
+
+        let properties = ArnResourceProperties {
+            home_tenant_id: self.tenant_id.clone(),
+            resource_home_tenant_id: self.tenant_id.clone(),
+            resources_container: "Inline".to_string(),
+            resource_location: "global".to_string(),
+            publisher_info: random_publisher_info(),
+            resources: vec![resource_data],
+        };
+
+        ArnResource::new(resource_id, ResourceType::Relationship, properties)
+    }
+}
+
+/// Helper functions for creating Event Grid events
+impl ManagementGroupResource {
+    /// Create Event Grid event with full payload
+    pub fn to_event_grid_event_full(&self, change_action: &str) -> EventGridEvent {
+        let resource_id = format!("/providers/Microsoft.Management/managementGroups/{}", self.id);
+        let correlation_id = Uuid::new_v4().to_string();
+        let event_type = format!("Microsoft.Management/managementGroups/{}",
+            if change_action == "Create" { "write" } else { "write" });
+
+        let parent_value = match &self.parent_id {
+            Some(parent_id) => json!({
+                "id": format!("/providers/Microsoft.Management/managementGroups/{}", parent_id)
+            }),
+            None => Value::Null,
+        };
+
+        let arm_resource = json!({
+            "id": resource_id.clone(),
+            "name": self.name,
+            "type": "Microsoft.Management/managementGroups",
+            "location": "global",
+            "properties": {
+                "displayName": self.display_name,
+                "tenantId": self.tenant_id,
+                "details": {
+                    "parent": parent_value
+                },
+                "provisioningState": "Succeeded"
+            }
+        });
+
+        let resource_data = ArnResourcesData {
+            resource_id: resource_id.clone(),
+            correlation_id,
+            source_resource_id: None,
+            api_version: Some("2021-04-01".to_string()),
+            resource_event_time: Some(self.created_at.to_rfc3339()),
+            home_tenant_id: Some(self.tenant_id.clone()),
+            resource_home_tenant_id: Some(self.tenant_id.clone()),
+            status_code: Some("OK".to_string()),
+            arm_resource: Some(arm_resource),
+            resource_system_properties: Some(ResourceSystemProperties {
+                created_by: self.created_by.clone(),
+                created_time: self.created_at.to_rfc3339(),
+                last_modified_by: None,
+                last_modified_time: None,
+                change_action: change_action.to_string(),
+            }),
+            additional_resource_properties: None,
+        };
+
+        EventGridEvent {
+            topic: format!("custom-domain-topic/eg-topic"),
+            subject: resource_id.clone(),
+            event_type,
+            event_time: self.created_at.to_rfc3339(),
+            id: Uuid::new_v4().to_string(),
+            data: ArnNotificationData {
+                resource_location: "global".to_string(),
+                publisher_info: random_publisher_info(),
+                api_version: Some("2020-03-01-preview".to_string()),
+                resources: vec![resource_data],
+            },
+            data_version: "3.0".to_string(),
+            metadata_version: "1".to_string(),
+        }
+    }
+
+    /// Create Event Grid event with payload-less format (resourceId only)
+    pub fn to_event_grid_event_payloadless(&self) -> EventGridEvent {
+        let resource_id = format!("/providers/Microsoft.Management/managementGroups/{}", self.id);
+        let correlation_id = Uuid::new_v4().to_string();
+        let event_type = "Microsoft.Management/managementGroups/write".to_string();
+
+        let resource_data = ArnResourcesData {
+            resource_id: resource_id.clone(),
+            correlation_id,
+            source_resource_id: None,
+            api_version: None,
+            resource_event_time: None,
+            home_tenant_id: None,
+            resource_home_tenant_id: None,
+            status_code: None,
+            arm_resource: None,
+            resource_system_properties: None,
+            additional_resource_properties: None,
+        };
+
+        EventGridEvent {
+            topic: format!("custom-domain-topic/eg-topic"),
+            subject: resource_id.clone(),
+            event_type,
+            event_time: self.created_at.to_rfc3339(),
+            id: Uuid::new_v4().to_string(),
+            data: ArnNotificationData {
+                resource_location: "global".to_string(),
+                publisher_info: random_publisher_info(),
+                api_version: None,
+                resources: vec![resource_data],
+            },
+            data_version: "3.0".to_string(),
+            metadata_version: "1".to_string(),
+        }
+    }
+}
+
+/// Helper to create batched Event Grid events
+pub fn create_batched_event_grid_event(
+    resources: Vec<&ManagementGroupResource>,
+    format: NotificationFormat,
+    subscription_id: &str,
+) -> EventGridEvent {
+    let subject = format!("/subscriptions/{}", subscription_id);
+    let event_time = resources.first().map(|r| r.created_at).unwrap_or_else(|| Utc::now());
+
+    let resources_data: Vec<ArnResourcesData> = resources.iter().map(|mg| {
+        let resource_id = format!("/providers/Microsoft.Management/managementGroups/{}", mg.id);
+        let correlation_id = Uuid::new_v4().to_string();
+
+        match format {
+            NotificationFormat::BatchedIds => {
+                // Payload-less batched format
+                ArnResourcesData {
+                    resource_id,
+                    correlation_id,
+                    source_resource_id: None,
+                    api_version: None,
+                    resource_event_time: None,
+                    home_tenant_id: None,
+                    resource_home_tenant_id: None,
+                    status_code: None,
+                    arm_resource: None,
+                    resource_system_properties: None,
+                    additional_resource_properties: None,
+                }
+            },
+            NotificationFormat::BatchedPayloads => {
+                // Full payload batched format
+                let parent_value = match &mg.parent_id {
+                    Some(parent_id) => json!({
+                        "id": format!("/providers/Microsoft.Management/managementGroups/{}", parent_id)
+                    }),
+                    None => Value::Null,
+                };
+
+                let arm_resource = json!({
+                    "id": resource_id.clone(),
+                    "name": mg.name,
+                    "type": "Microsoft.Management/managementGroups",
+                    "location": "global",
+                    "properties": {
+                        "displayName": mg.display_name,
+                        "tenantId": mg.tenant_id,
+                        "details": {
+                            "parent": parent_value
+                        },
+                        "provisioningState": "Succeeded"
+                    }
+                });
+
+                ArnResourcesData {
+                    resource_id,
+                    correlation_id,
+                    source_resource_id: None,
+                    api_version: None, // At data level for batched
+                    resource_event_time: Some(mg.created_at.to_rfc3339()),
+                    home_tenant_id: Some(mg.tenant_id.clone()),
+                    resource_home_tenant_id: Some(mg.tenant_id.clone()),
+                    status_code: Some("OK".to_string()),
+                    arm_resource: Some(arm_resource),
+                    resource_system_properties: Some(ResourceSystemProperties {
+                        created_by: mg.created_by.clone(),
+                        created_time: mg.created_at.to_rfc3339(),
+                        last_modified_by: None,
+                        last_modified_time: None,
+                        change_action: "Create".to_string(),
+                    }),
+                    additional_resource_properties: None,
+                }
+            },
+            _ => panic!("Invalid format for batched event"),
+        }
+    }).collect();
+
+    EventGridEvent {
+        topic: "custom-domain-topic/eg-topic".to_string(),
+        subject,
+        event_type: "Microsoft.Management/managementGroups/write".to_string(),
+        event_time: event_time.to_rfc3339(),
+        id: Uuid::new_v4().to_string(),
+        data: ArnNotificationData {
+            resource_location: "global".to_string(),
+            publisher_info: random_publisher_info(),
+            api_version: if format == NotificationFormat::BatchedPayloads {
+                Some("2020-03-01".to_string())
+            } else {
+                Some("2020-03-01-privatepreview".to_string())
+            },
+            resources: resources_data,
+        },
+        data_version: "3.0".to_string(),
+        metadata_version: "1".to_string(),
+    }
+}

--- a/data-tools/arn/src/main.rs
+++ b/data-tools/arn/src/main.rs
@@ -1,0 +1,162 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+
+use chrono::NaiveDateTime;
+use clap::{Args, Parser, Subcommand};
+use script::generate_test_scripts;
+
+mod arn;
+mod script;
+
+/// String constant representing the default ARN data output folder path
+const DEFAULT_OUTPUT_FOLDER_PATH: &str = "./arn_data";
+
+#[derive(Parser)]
+#[command(name = "ARN")]
+#[command(about = "CLI for generating fictional Azure Resource Notification (ARN) test data", long_about = None)]
+struct Params {
+    /// The path for generated ARN test data
+    #[arg(short = 'o', long = "output", env = "ARN_OUTPUT_PATH")]
+    pub output_folder_path: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate ARN test scripts (bootstrap and source change scripts)
+    Generate {
+        #[command(flatten)]
+        data_selection: GenerateCommandArgs,
+
+        /// A flag to indicate whether existing files should be overwritten
+        #[arg(short = 'w', long, default_value_t = false)]
+        overwrite: bool,
+    },
+}
+
+#[derive(Args, Debug)]
+struct GenerateCommandArgs {
+    /// The ID of the test scenario
+    #[arg(short = 'i', long)]
+    test_id: String,
+
+    /// The source ID for the ARN events
+    #[arg(short = 'd', long, default_value = "arn-events")]
+    source_id: String,
+
+    /// Number of management groups to generate
+    #[arg(short = 'm', long, default_value_t = 10)]
+    management_group_count: usize,
+
+    /// Number of service groups to generate
+    #[arg(short = 'g', long, default_value_t = 5)]
+    service_group_count: usize,
+
+    /// Number of relationship resources to generate
+    #[arg(short = 'r', long, default_value_t = 20)]
+    relationship_count: usize,
+
+    /// Maximum depth of management group hierarchy
+    #[arg(short = 'p', long, default_value_t = 4)]
+    hierarchy_depth: usize,
+
+    /// Start datetime for the test scenario
+    /// Supported formats are here https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.parse_from_str
+    #[arg(short = 's', long)]
+    start_time: Option<NaiveDateTime>,
+
+    /// Number of change events to generate
+    #[arg(short = 'c', long, default_value_t = 50)]
+    change_count: usize,
+
+    /// Duration in seconds over which to spread the change events
+    #[arg(short = 'u', long, default_value_t = 3600)]
+    change_duration_secs: u64,
+
+    /// Tenant ID to use for resources (will be generated if not provided)
+    #[arg(short = 't', long)]
+    tenant_id: Option<String>,
+
+    /// Notification format: full-payload, payload-less, batched-ids, batched-payloads
+    #[arg(short = 'f', long, default_value = "full-payload")]
+    notification_format: String,
+
+    /// Batch size for batched notification formats
+    #[arg(short = 'b', long, default_value_t = 3)]
+    batch_size: usize,
+
+    /// Subscription ID for batched notifications
+    #[arg(long)]
+    subscription_id: Option<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let params = Params::parse();
+
+    let output_folder_path = params
+        .output_folder_path
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT_FOLDER_PATH));
+
+    let res = match params.command {
+        Commands::Generate {
+            data_selection,
+            overwrite,
+        } => handle_generate_command(data_selection, output_folder_path, overwrite).await,
+    };
+
+    match res {
+        Ok(_) => {
+            println!("Command completed successfully");
+        }
+        Err(e) => {
+            eprintln!("arn command failed: {:?}", e);
+        }
+    }
+}
+
+async fn handle_generate_command(
+    args: GenerateCommandArgs,
+    output_folder_path: PathBuf,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    log::info!("Generate command using {:?}", args);
+
+    // Display a summary of what the command is going to do.
+    println!("Generating ARN Test Scripts:");
+    println!("  - test ID: {}", args.test_id);
+    println!("  - source ID: {}", args.source_id);
+    println!("  - management groups: {}", args.management_group_count);
+    println!("  - service groups: {}", args.service_group_count);
+    println!("  - relationships: {}", args.relationship_count);
+    println!("  - hierarchy depth: {}", args.hierarchy_depth);
+    println!("  - notification format: {}", args.notification_format);
+    println!("  - batch size: {}", args.batch_size);
+    println!("  - change events: {}", args.change_count);
+    println!("  - change duration: {} seconds", args.change_duration_secs);
+    println!("  - output folder: {:?}", output_folder_path);
+    println!("  - overwrite: {}", overwrite);
+
+    let script_root_path = output_folder_path.join("scripts");
+
+    generate_test_scripts(&args, script_root_path, overwrite).await?;
+
+    Ok(())
+}

--- a/data-tools/arn/src/script.rs
+++ b/data-tools/arn/src/script.rs
@@ -1,0 +1,334 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+
+use chrono::{FixedOffset, TimeZone, Utc};
+use rand::Rng;
+use test_data_store::scripts::bootstrap_script_file_writer::{
+    BootstrapScriptWriter, BootstrapScriptWriterSettings,
+};
+use test_data_store::scripts::change_script_file_writer::{
+    ChangeScriptWriter, ChangeScriptWriterSettings,
+};
+use test_data_store::scripts::{
+    BootstrapHeaderRecord, BootstrapScriptRecord, ChangeHeaderRecord,
+    ChangeScriptRecord, NodeRecord, SourceChangeEvent, SourceChangeEventPayload, SourceChangeEventSourceInfo,
+    SourceChangeRecord,
+};
+use tokio::fs;
+use uuid::Uuid;
+
+use crate::arn::generator::{ArnDataGenerator, ChangeEvent, GeneratorConfig};
+use crate::arn::models::{create_batched_event_grid_event, NotificationFormat};
+use crate::GenerateCommandArgs;
+
+pub async fn generate_test_scripts(
+    args: &GenerateCommandArgs,
+    script_root_path: PathBuf,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    log::info!("Generating test scripts for test ID: {}", args.test_id);
+
+    let script_path = script_root_path.join(format!("{}/sources/{}", args.test_id, args.source_id));
+
+    if overwrite && script_path.exists() {
+        fs::remove_dir_all(&script_path).await?;
+    }
+
+    if !script_path.exists() {
+        fs::create_dir_all(&script_path).await?;
+    }
+
+    // Determine tenant ID
+    let tenant_id = args
+        .tenant_id
+        .clone()
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    // Determine subscription ID for batched notifications
+    let subscription_id = args
+        .subscription_id
+        .clone()
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    // Parse notification format
+    let notification_format = match args.notification_format.as_str() {
+        "full-payload" => NotificationFormat::FullPayload,
+        "payload-less" => NotificationFormat::PayloadLess,
+        "batched-ids" => NotificationFormat::BatchedIds,
+        "batched-payloads" => NotificationFormat::BatchedPayloads,
+        _ => {
+            eprintln!("Invalid notification format: {}. Using full-payload.", args.notification_format);
+            NotificationFormat::FullPayload
+        }
+    };
+
+    // Determine start time
+    let start_time_naive = args.start_time.unwrap_or_else(|| Utc::now().naive_utc());
+    let start_time = start_time_naive.and_utc();
+
+    // Create generator config
+    let config = GeneratorConfig {
+        tenant_id: tenant_id.clone(),
+        management_group_count: args.management_group_count,
+        service_group_count: args.service_group_count,
+        relationship_count: args.relationship_count,
+        hierarchy_depth: args.hierarchy_depth,
+        start_time,
+    };
+
+    let mut generator = ArnDataGenerator::new(config);
+
+    // Generate resources
+    println!("Generating resources...");
+    let management_groups = generator.generate_management_groups();
+    let service_groups = generator.generate_service_groups();
+    let relationships =
+        generator.generate_relationships(&management_groups, &service_groups);
+
+    println!("  - Generated {} management groups", management_groups.len());
+    println!("  - Generated {} service groups", service_groups.len());
+    println!("  - Generated {} relationships", relationships.len());
+
+    // GENERATE BOOTSTRAP SCRIPT
+    println!("Generating bootstrap script...");
+    let bootstrap_script_path = script_path.join("bootstrap_scripts");
+
+    let mut bootstrap_script_writer = BootstrapScriptWriter::new(BootstrapScriptWriterSettings {
+        folder_path: bootstrap_script_path,
+        script_name: "arn_resources".to_string(),
+        max_size: Some(1000),
+    })?;
+
+    let header = BootstrapScriptRecord::Header(BootstrapHeaderRecord {
+        start_time: FixedOffset::east_opt(0)
+            .unwrap()
+            .from_utc_datetime(&start_time_naive),
+        description: format!(
+            "Drasi Bootstrap Data Script for TestID {}, SourceID: {}",
+            args.test_id, args.source_id
+        ),
+    });
+    bootstrap_script_writer.write_record(&header)?;
+
+    // Write management groups based on notification format
+    match notification_format {
+        NotificationFormat::BatchedIds | NotificationFormat::BatchedPayloads => {
+            // For batched formats, group resources into batches
+            for batch in management_groups.chunks(args.batch_size) {
+                let event_grid_event = create_batched_event_grid_event(
+                    batch.iter().collect(),
+                    notification_format,
+                    &subscription_id,
+                );
+
+                // Convert Event Grid event to Node record with special handling
+                let record = BootstrapScriptRecord::Node(NodeRecord {
+                    id: format!("event-grid/{}", event_grid_event.id),
+                    labels: vec!["EventGridEvent".to_string()],
+                    properties: serde_json::to_value(&event_grid_event)?,
+                });
+                bootstrap_script_writer.write_record(&record)?;
+            }
+        }
+        NotificationFormat::FullPayload => {
+            // Full payload - one Event Grid event per resource
+            for mg in &management_groups {
+                let event_grid_event = mg.to_event_grid_event_full("Create");
+                let record = BootstrapScriptRecord::Node(NodeRecord {
+                    id: format!("event-grid/{}", event_grid_event.id),
+                    labels: vec!["EventGridEvent".to_string()],
+                    properties: serde_json::to_value(&event_grid_event)?,
+                });
+                bootstrap_script_writer.write_record(&record)?;
+            }
+        }
+        NotificationFormat::PayloadLess => {
+            // Payload-less - one Event Grid event per resource with minimal data
+            for mg in &management_groups {
+                let event_grid_event = mg.to_event_grid_event_payloadless();
+                let record = BootstrapScriptRecord::Node(NodeRecord {
+                    id: format!("event-grid/{}", event_grid_event.id),
+                    labels: vec!["EventGridEvent".to_string()],
+                    properties: serde_json::to_value(&event_grid_event)?,
+                });
+                bootstrap_script_writer.write_record(&record)?;
+            }
+        }
+    }
+
+    // Write service groups
+    for sg in &service_groups {
+        let arn_resource = sg.to_arn_resource("Create");
+        let record = BootstrapScriptRecord::Node(NodeRecord {
+            id: arn_resource.id,
+            labels: arn_resource.labels,
+            properties: serde_json::to_value(&arn_resource.properties)?,
+        });
+        bootstrap_script_writer.write_record(&record)?;
+    }
+
+    // Write relationships
+    for rel in &relationships {
+        let arn_resource = rel.to_arn_resource("Create");
+        let record = BootstrapScriptRecord::Node(NodeRecord {
+            id: arn_resource.id,
+            labels: arn_resource.labels,
+            properties: serde_json::to_value(&arn_resource.properties)?,
+        });
+        bootstrap_script_writer.write_record(&record)?;
+    }
+
+    println!(
+        "  - Bootstrap script written with {} resources",
+        management_groups.len() + service_groups.len() + relationships.len()
+    );
+
+    // GENERATE CHANGE SCRIPT
+    println!("Generating change script...");
+    let mut change_script_writer = ChangeScriptWriter::new(ChangeScriptWriterSettings {
+        folder_path: script_path.clone(),
+        script_name: "source_change_scripts".to_string(),
+        max_size: Some(1000),
+    })?;
+
+    let header = ChangeScriptRecord::Header(ChangeHeaderRecord {
+        start_time: FixedOffset::east_opt(0)
+            .unwrap()
+            .from_utc_datetime(&start_time_naive),
+        description: format!(
+            "Drasi Source Change Script for TestID {}, SourceID: {}",
+            args.test_id, args.source_id
+        ),
+    });
+    change_script_writer.write_record(&header)?;
+
+    // Generate change events
+    let change_events = generator.generate_change_events(
+        &management_groups,
+        &service_groups,
+        args.change_count,
+        args.change_duration_secs,
+    );
+
+    println!("  - Generated {} change events", change_events.len());
+
+    let start_datetime_ns = start_time.timestamp_nanos_opt().unwrap_or_default() as u64;
+    let mut lsn: u64 = 0;
+    let mut rng = rand::thread_rng();
+    let mut current_offset_ns: u64 = 0;
+
+    for event in change_events {
+        // Add a random interval to the offset (between 100ms and 5s in nanoseconds)
+        let interval_ns = rng.gen_range(100_000_000..5_000_000_000);
+        current_offset_ns += interval_ns;
+
+        match event {
+            ChangeEvent::Insert { management_group } => {
+                let arn_resource = management_group.to_arn_resource("Create");
+                let ts_ns = start_datetime_ns + current_offset_ns;
+
+                // Generate realistic reactivator timing (processing takes 1-10ms)
+                let reactivator_start_ns = ts_ns + rng.gen_range(1_000_000..5_000_000);
+                let reactivator_end_ns = reactivator_start_ns + rng.gen_range(1_000_000..10_000_000);
+
+                let source_info = SourceChangeEventSourceInfo {
+                    db: args.source_id.clone(),
+                    table: "node".to_string(),
+                    ts_ns,
+                    lsn,
+                };
+
+                let record = ChangeScriptRecord::SourceChange(SourceChangeRecord {
+                    offset_ns: current_offset_ns,
+                    source_change_event: SourceChangeEvent {
+                        op: "i".to_string(),
+                        reactivator_start_ns,
+                        reactivator_end_ns,
+                        payload: SourceChangeEventPayload {
+                            source: source_info,
+                            before: serde_json::Value::Null,
+                            after: serde_json::json!({
+                                "id": arn_resource.id,
+                                "labels": arn_resource.labels,
+                                "properties": arn_resource.properties,
+                            }),
+                        },
+                    },
+                });
+
+                change_script_writer.write_record(&record)?;
+                lsn += 1;
+            }
+            ChangeEvent::Update {
+                management_group,
+                new_display_name,
+                updated_at,
+                updated_by,
+            } => {
+                let before_arn = management_group.to_arn_resource("Create");
+                let after_arn =
+                    management_group.to_updated_arn_resource(new_display_name, updated_at, updated_by);
+
+                let ts_ns = start_datetime_ns + current_offset_ns;
+
+                // Generate realistic reactivator timing (processing takes 1-10ms)
+                let reactivator_start_ns = ts_ns + rng.gen_range(1_000_000..5_000_000);
+                let reactivator_end_ns = reactivator_start_ns + rng.gen_range(1_000_000..10_000_000);
+
+                let source_info = SourceChangeEventSourceInfo {
+                    db: args.source_id.clone(),
+                    table: "node".to_string(),
+                    ts_ns,
+                    lsn,
+                };
+
+                let record = ChangeScriptRecord::SourceChange(SourceChangeRecord {
+                    offset_ns: current_offset_ns,
+                    source_change_event: SourceChangeEvent {
+                        op: "u".to_string(),
+                        reactivator_start_ns,
+                        reactivator_end_ns,
+                        payload: SourceChangeEventPayload {
+                            source: source_info,
+                            before: serde_json::json!({
+                                "id": before_arn.id,
+                                "labels": before_arn.labels,
+                                "properties": before_arn.properties,
+                            }),
+                            after: serde_json::json!({
+                                "id": after_arn.id,
+                                "labels": after_arn.labels,
+                                "properties": after_arn.properties,
+                            }),
+                        },
+                    },
+                });
+
+                change_script_writer.write_record(&record)?;
+                lsn += 1;
+            }
+        }
+    }
+
+    println!("  - Change script written with {} events", lsn);
+
+    println!("\nTest scripts generated successfully!");
+    println!("  Location: {:?}", script_path);
+    println!("  Tenant ID: {}", tenant_id);
+    println!("  Start Time: {}", start_time_naive);
+
+    Ok(())
+}

--- a/data-tools/arn/summary.md
+++ b/data-tools/arn/summary.md
@@ -1,0 +1,351 @@
+# Azure Resource Notifications (ARN) and Azure Resource Graph (ARG) Architecture Summary
+
+## Overview
+
+The GroupsRP service processes Azure Resource Notifications (ARN) events and uses Azure Resource Graph (ARG) for validation and cleanup operations. The system manages relationships between Azure resources, particularly for Management Groups and Service Groups functionality.
+
+**Key Finding**: The system is **fully compliant with ARN Schema V3** specification, supporting both inline resource notifications and blob URI notifications with comprehensive field mapping.
+
+## ARN (Azure Resource Notification) Data Flow
+
+### Data Source
+- **Source**: Azure Event Grid
+- **Entry Point**: `NotificationWriterService/Controllers/ArnEventsController.cs`
+- **Authentication**: Service-to-Service (S2S) with Azure Event Grid webhook role
+- **Endpoints**:
+  - `/providers/Microsoft.Management/arnEvents`
+  - `/providers/Microsoft.Management/events`
+  - `/arn/arnEvents`
+  - `/arn/events`
+
+### Supported ARN Event Types
+
+#### 1. Tracked Resource Notifications (from ARM)
+- **What**: Direct Azure resources (Management Groups, Service Groups)
+- **Source**: Azure Resource Manager (ARM)
+- **Event Types**:
+  - Resource Write Events
+  - Resource Delete Events
+- **Processing Method**: `ProcessInlineTrackedResourceNotification()`
+
+#### 2. Proxy Resource Notifications (Relationships)
+- **What**: Relationship resources (Service Group Members, Dependencies)
+- **Source**: ARM or relationship providers
+- **Event Types**:
+  - Relationship Write/Snapshot Events
+  - Relationship Delete Events
+- **Processing Method**: `ProcessProxyResourceNotification()`
+
+#### 3. Blob Notifications
+- **What**: Large-scale or batch notifications
+- **Source**: Azure Storage
+- **Processing Method**: `ProcessBlobNotification()`
+
+### ARN Processing Pipeline
+
+```
+Event Grid → ArnEventsController → Event Classification → Data Extraction → Validation (ARG) → Storage (Cosmos DB)
+```
+
+1. **Event Reception**: Events received via HTTP POST from Event Grid
+2. **Event Parsing**: `EventGridEvent.ParseMany()` parses incoming events
+3. **Type Detection**: System determines event category using helper methods
+4. **Data Extraction**: Resource IDs, tenant info, and metadata extracted
+5. **Channel Processing**: Events queued in appropriate processing channels
+6. **Storage**: Valid data stored in Cosmos DB after processing
+
+### Processing Channels
+
+#### Tracked Resources
+- **Write Channel**: `TrackedResourceWriteChannel`
+- **Delete Channel**: `TrackedResourceDeleteChannel`
+- **Processors**: 
+  - `TrackedResourceWriter` → Cosmos DB
+  - `TrackedResourceRemover` → Cosmos DB
+
+#### Relationship Resources
+- **Write Channel**: `RelationshipResourceWriteChannel`
+- **Delete Channel**: `RelationshipResourceDeleteChannel`
+- **Processors**:
+  - `RelationshipWriteProcessor` → Cosmos DB
+  - `RelationshipDeleteProcessor` → Cosmos DB
+
+## ARN Schema V3 Compliance
+
+### Data Model Implementation
+
+The system implements comprehensive ARN Schema V3 compliance through several model classes:
+
+#### Main Event Data (`ArnEventData.cs`)
+```csharp
+public class ArnEventData
+{
+    [JsonProperty("homeTenantId")]
+    public string? HomeTenantId { get; set; }
+
+    [JsonProperty("resourceHomeTenantId")]
+    public string? ResourceHomeTenantId { get; set; }
+
+    [JsonProperty("resourcesContainer")]
+    public string? ResourcesContainer { get; set; }
+
+    [JsonProperty("resourceLocation")]
+    public string? ResourceLocation { get; set; }
+
+    [JsonProperty("publisherInfo")]
+    public string? PublisherInfo { get; set; }
+
+    [JsonProperty("apiVersion")]
+    public string? ApiVersion { get; set; }
+
+    [JsonProperty("resources")]
+    public ArnResourcesData[]? Resources { get; set; }
+
+    [JsonProperty("resourcesBlobInfo")]
+    public ArnResourcesBlobInfo? ResourcesBlobInfo { get; set; }
+
+    [JsonProperty("additionalBatchProperties")]
+    public NotificationsBatchProperties? AdditionalBatchProperties { get; set; }
+
+    // Helper method to determine event type
+    public bool IsInlineResourceNotification() => Resources?.Length > 0;
+}
+```
+
+#### Resource Data (`ArnResourcesData.cs`)
+```csharp
+public class ArnResourcesData
+{
+    [JsonProperty("resourceId", Required = Required.Always)]
+    public string ResourceId { get; set; } = string.Empty;
+
+    [JsonProperty("correlationId", Required = Required.Always)]
+    public string CorrelationId { get; set; } = string.Empty;
+
+    [JsonProperty("resourceEventTime")]
+    public DateTime? ResourceEventTime { get; set; }
+
+    [JsonProperty("homeTenantId")]
+    public string? HomeTenantId { get; set; }
+
+    [JsonProperty("armResource")]
+    public JObject? ArmResource { get; set; }
+
+    [JsonProperty("resourceSystemProperties")]
+    public ArnResourceSystemProperties? ResourceSystemProperties { get; set; }
+}
+```
+
+### Dual Event Format Support
+- **Inline Resources**: Events with `resources` array for immediate processing
+- **Blob URI**: Events with `resourcesBlobInfo` for large batches stored in blob storage
+
+## ARG (Azure Resource Graph) Role
+
+### Purpose
+ARG provides **validation and cleanup services** - it does NOT store data but validates data integrity.
+
+### Key Functions
+
+#### 1. Resource Existence Validation
+- **Purpose**: Verify target resources exist before creating relationships
+- **Query Type**: Source ID validation in tenant
+
+#### 2. Cleanup Operations
+- **Purpose**: Find orphaned Service Group Member relationships
+- **Query**: Find relationships where source resources no longer exist
+
+#### 3. Resource Count Validation
+- **Purpose**: Validate subscription limits before resource creation
+- **Query**: Count resources by type and subscription
+
+### Key ARG Queries
+
+```kusto
+-- Service Group Member Cleanup
+RelationshipResources
+    | where type =~ "microsoft.relationships/servicegroupmember"
+    | where tenantId =~ "{tenantId}"
+    | extend sourceId = properties.SourceId
+    | project sourceId, id
+
+-- Resource Count Validation
+{table}
+    | where type =~ "{resourceType}"
+    | summarize count() by type, subscriptionId
+    | project count=count_, subscriptionId, type
+
+-- Source ID Validation
+Resources
+    | where id in~ ({sourceIds})
+    | where tenantId =~ "{tenantId}"
+    | project id
+```
+
+## Data Storage Architecture
+
+### Cosmos DB (Primary Storage)
+- **Role**: Write-through cache and persistent storage
+- **Content**: 
+  - Resource entries (Management Groups, Service Groups metadata)
+  - Relationship data (Service Group Member relationships, dependencies)
+  - Processed notification state
+- **Database**: `ResourceEntryDataProvider.DatabaseId`
+- **Container**: `ResourceEntryDataProvider.ResourceContainerId`
+
+### SQL Server (Secondary Storage)
+- **Role**: Service Groups metadata and configuration
+- **Use Case**: Traditional relational data requiring ACID transactions
+
+## Background Processing
+
+### Key Jobs
+- **SingleTenantServiceGroupMemberCleanupJob**: Uses ARG to find and clean orphaned relationships
+- **ServiceGroupMemberCRUDJob**: Handles CRUD operations for Service Group Members
+- **SyncSubscriptionWithArmJob**: Synchronizes subscription data from ARM
+
+### Processing Flow
+1. **Background Service**: `NotificationProcessingBackgroundService` manages lifecycle
+2. **Channel Readers**: Process queued events asynchronously
+3. **Retry Logic**: Built-in retry for transient failures
+4. **Error Handling**: Dead letter queuing for failed operations
+
+## Key Architectural Patterns
+
+### Data Flow Direction
+- **ARN**: Event Grid → NotificationWriterService → Cosmos DB (Inbound)
+- **ARG**: GroupsRP → Azure Resource Graph (Outbound queries)
+- **Cosmos DB**: Local storage for processed data (Storage)
+
+### Why This Architecture?
+1. **Scalability**: Asynchronous processing handles high-volume notifications
+2. **Reliability**: Channels provide buffering and retry capabilities
+3. **Consistency**: ARG queries ensure relationships point to valid resources
+4. **Multi-tenancy**: Supports resource management across Azure tenants
+5. **Real-time Updates**: Immediate notification processing keeps data current
+
+## Key Processing Functions by ARN Event Type
+
+### 1. Event Reception & Classification (`ArnEventsController.cs`)
+- `EventGridEvent.ParseMany()` - Parse incoming Event Grid events
+- `eventGridEvent.GetData<ArnEventData>()` - Extract ARN data from event
+- `ProcessInlineTrackedResourceNotification()` - Handle inline resource events
+- `ProcessBlobNotification()` - Handle blob URI events  
+- `ProcessProxyResourceNotification()` - Handle relationship events
+
+### 2. Tracked Resource Processing (`TrackedResourceWriter.cs`)
+- `ProcessItemAsync()` - Main processing entry point
+- `AsyncRetry.ExecuteAsync()` - Retry wrapper for reliability
+- `resourceEntryDataProvider.CreateOrUpdateResource()` - Write to Cosmos DB
+- `resourceEntryDataProvider.DeleteResource()` - Remove from Cosmos DB
+
+### 3. Relationship Processing (`RelationshipWriteProcessor.cs`)
+- `HandleRelationshipWrite()` - Main relationship creation
+- `resourceEntryDataProvider.CreateAffinitySlot()` - Create source/target slots
+- `edgeDataProvider.CreateEdge()` - Create relationship edge
+- `HandleRelationshipDelete()` - Remove relationships
+
+### 4. ARG Validation (`ResourceGraphEngine.cs`)
+- `QueryAsync()` - Execute Kusto queries against ARG
+- `ValidateSourceResourceIds()` - Verify resources exist
+- `GetAllServiceGroupMembersInTenant()` - Find orphaned relationships
+- `GetSubscriptionResourceCount()` - Validate resource limits
+
+### 5. Background Processing (`NotificationProcessingBackgroundService`)
+- `StartAsync()` - Initialize processing channels
+- `ExecuteAsync()` - Main processing loop
+- `ProcessTrackedResourceWrites()` - Handle write channel
+- `ProcessRelationshipWrites()` - Handle relationship channel
+
+### 6. Event Classification Helpers (`ArnEventData.cs`)
+- `IsInlineResourceNotification()` - Check for inline resources
+- `IsBlobResourceNotification()` - Check for blob URI format
+- `IsTrackedResourceEvent()` - Identify ARM resource events
+- `IsRelationshipEvent()` - Identify relationship events
+
+## Development Dependencies
+
+### Cosmos DB Emulator
+- **Required for**: Local development and testing
+- **Reason**: NotificationWriterService needs document storage for relationship graphs
+- **Configuration**: Special startup parameters for high throughput testing
+- **Initialization**: `CosmosDbDevelopmentInitializer` sets up development database/containers
+
+### Configuration Files
+- **Location**: `GroupsWorker.Tests/app.config`, deployment configs
+- **ARG Settings**: Base service URI, API version, timeouts, retry policies
+- **Cosmos Settings**: Connection strings, partition strategies, TTL settings
+
+
+Based on the GroupsRP implementation, your test data should follow this pattern:
+```json
+{
+  "homeTenantId": "your-tenant-id",
+  "resourceHomeTenantId": "resource-tenant-id", 
+  "resourcesContainer": "Inline", // or "Blob"
+  "resourceLocation": "global",
+  "publisherInfo": "Microsoft.Management", 
+  "apiVersion": "2021-04-01",
+  "resources": [
+    {
+      "resourceId": "/subscriptions/{sub-id}/resourceGroups/{rg}/providers/Microsoft.Management/managementGroups/{mg-id}",
+      "correlationId": "guid-here",
+      "resourceEventTime": "2025-11-14T20:30:00Z",
+      "homeTenantId": "tenant-id",
+      "statusCode": "200",
+      "armResource": {
+        "id": "/subscriptions/{sub-id}/resourceGroups/{rg}/providers/Microsoft.Management/managementGroups/{mg-id}",
+        "name": "my-management-group",
+        "type": "Microsoft.Management/managementGroups",
+        "properties": {
+          "displayName": "My Management Group",
+          "details": {
+            "parent": {
+              "id": "/providers/Microsoft.Management/managementGroups/parent-id"
+            }
+          }
+        }
+      },
+      "resourceSystemProperties": {
+        "createdBy": "user@domain.com",
+        "createdTime": "2025-11-14T20:30:00Z",
+        "changeAction": "Create"
+      }
+    }
+  ]
+}{
+  "homeTenantId": "your-tenant-id",
+  "resourceHomeTenantId": "resource-tenant-id", 
+  "resourcesContainer": "Inline", // or "Blob"
+  "resourceLocation": "global",
+  "publisherInfo": "Microsoft.Management", 
+  "apiVersion": "2021-04-01",
+  "resources": [
+    {
+      "resourceId": "/subscriptions/{sub-id}/resourceGroups/{rg}/providers/Microsoft.Management/managementGroups/{mg-id}",
+      "correlationId": "guid-here",
+      "resourceEventTime": "2025-11-14T20:30:00Z",
+      "homeTenantId": "tenant-id",
+      "statusCode": "200",
+      "armResource": {
+        "id": "/subscriptions/{sub-id}/resourceGroups/{rg}/providers/Microsoft.Management/managementGroups/{mg-id}",
+        "name": "my-management-group",
+        "type": "Microsoft.Management/managementGroups",
+        "properties": {
+          "displayName": "My Management Group",
+          "details": {
+            "parent": {
+              "id": "/providers/Microsoft.Management/managementGroups/parent-id"
+            }
+          }
+        }
+      },
+      "resourceSystemProperties": {
+        "createdBy": "user@domain.com",
+        "createdTime": "2025-11-14T20:30:00Z",
+        "changeAction": "Create"
+      }
+    }
+  ]
+}
+```

--- a/data-tools/redis/redis-stream-cli/Cargo.toml
+++ b/data-tools/redis/redis-stream-cli/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "redis-stream-cli"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "redis-stream-cli"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0.86"
+clap = { version = "4.5.18", features = ["derive", "env"] }
+env_logger = "0.7.1"
+log = "0.4"
+tokio = { version = "1.37.0", features = ["full"] }
+redis = { version = "0.27.5", features = ["tokio-comp"] }
+serde = { version = "1.0.163", features = ["derive"] }
+serde_json = "1.0.96"
+chrono = { version = "0.4.38", features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3.10"

--- a/data-tools/redis/redis-stream-cli/Cargo.toml
+++ b/data-tools/redis/redis-stream-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-stream-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/data-tools/redis/redis-stream-cli/README.md
+++ b/data-tools/redis/redis-stream-cli/README.md
@@ -1,10 +1,15 @@
 # Redis Stream CLI
 
-A command-line utility for reading records from Redis streams and outputting them to console or file.
+A command-line utility for working with Redis streams - read stream records and list available streams.
 
 ## Overview
 
-`redis-stream-cli` is a Rust-based CLI tool that provides an easy way to read and export data from Redis streams. It supports reading from any position in a stream, limiting the number of records, and outputting in multiple formats (JSON or text).
+`redis-stream-cli` is a Rust-based CLI tool that provides an easy way to work with Redis streams. It supports:
+
+- **Reading stream records** from any position with multiple output formats
+- **Listing all streams** on a Redis server
+- **Automatic JSON parsing** in the `data` field for proper JSON objects (not escaped strings)
+- **Flexible output** to console or file with auto-generated filenames
 
 **Key Feature:** Automatically parses JSON in the `data` field, outputting proper JSON objects instead of escaped JSON strings. This makes the output directly usable by JSON processors and easier to read.
 
@@ -27,7 +32,20 @@ cargo run -p redis-stream-cli -- [OPTIONS]
 
 ## Usage
 
-### Command Line Arguments
+### Subcommands
+
+`redis-stream-cli` supports two subcommands:
+
+- **`read`** - Read records from a specific Redis stream
+- **`list`** - List all stream names available on a Redis server
+
+Use `redis-stream-cli --help` to see all available subcommands, or `redis-stream-cli <subcommand> --help` for detailed help on a specific subcommand.
+
+### `read` Subcommand
+
+Read records from a Redis stream with various filtering and output options.
+
+#### Arguments
 
 - `-u, --url <REDIS_URL>`: Redis server URL (default: `redis://localhost:6379`)
   - Can also be set via `REDIS_URL` environment variable
@@ -43,85 +61,146 @@ cargo run -p redis-stream-cli -- [OPTIONS]
   - Omit flag entirely: Outputs to console
 - `-o, --format <FORMAT>`: Output format: `json` or `text` (default: `json`)
 
-### Examples
+#### Examples
 
-#### Read all records from a stream and display as JSON
-
-```bash
-redis-stream-cli -s my-stream
-```
-
-#### Read from a specific Redis server
+##### Read all records from a stream and display as JSON
 
 ```bash
-redis-stream-cli -u redis://myserver:6379 -s my-stream
+redis-stream-cli read -s my-stream
 ```
 
-#### Read only 10 records
+##### Read from a specific Redis server
 
 ```bash
-redis-stream-cli -s my-stream -c 10
+redis-stream-cli read -u redis://myserver:6379 -s my-stream
 ```
 
-#### Read from a specific timestamp
+##### Read only 10 records
 
 ```bash
-redis-stream-cli -s my-stream -t 1609459200000-0
+redis-stream-cli read -s my-stream -c 10
 ```
 
-#### Read from the latest entries
+##### Read from a specific timestamp
 
 ```bash
-redis-stream-cli -s my-stream -t $
+redis-stream-cli read -s my-stream -t 1609459200000-0
 ```
 
-#### Auto-generate filename from stream name (creates my-stream.json)
+##### Read from the latest entries
 
 ```bash
-redis-stream-cli -s my-stream -f
+redis-stream-cli read -s my-stream -t $
 ```
 
-#### Auto-generate filename with text format (creates my-stream.txt)
+##### Auto-generate filename from stream name (creates my-stream.json)
 
 ```bash
-redis-stream-cli -s my-stream -f -o text
+redis-stream-cli read -s my-stream -f
 ```
 
-#### Output to a specific file in JSON format
+##### Auto-generate filename with text format (creates my-stream.txt)
 
 ```bash
-redis-stream-cli -s my-stream -f output.json
+redis-stream-cli read -s my-stream -f -o text
 ```
 
-#### Output to a specific file in text format
+##### Output to a specific file in JSON format
 
 ```bash
-redis-stream-cli -s my-stream -f output.txt -o text
+redis-stream-cli read -s my-stream -f output.json
 ```
 
-#### Using environment variable for Redis URL
+##### Output to a specific file in text format
+
+```bash
+redis-stream-cli read -s my-stream -f output.txt -o text
+```
+
+##### Using environment variable for Redis URL
 
 ```bash
 export REDIS_URL=redis://myserver:6379
-redis-stream-cli -s my-stream
+redis-stream-cli read -s my-stream
 ```
 
-#### Enable debug logging
+##### Enable debug logging
 
 ```bash
-RUST_LOG=debug redis-stream-cli -s my-stream
+RUST_LOG=debug redis-stream-cli read -s my-stream
 ```
 
-### Integration with Drasi Test Infrastructure
+### `list` Subcommand
+
+List all stream names available on a Redis server. Requires Redis 6.0+ for efficient stream type filtering.
+
+#### Arguments
+
+- `-u, --url <REDIS_URL>`: Redis server URL (default: `redis://localhost:6379`)
+  - Can also be set via `REDIS_URL` environment variable
+- `-f, --file [OUTPUT_FILE]`: Write output to file (optional filename)
+  - Without filename: Auto-generates filename `streams.json`
+  - With filename: Uses the specified filename (e.g., `-f my-streams.json`)
+  - Omit flag entirely: Outputs to console
+
+#### Examples
+
+##### List all streams and display on console
+
+```bash
+redis-stream-cli list
+```
+
+##### List streams from a specific Redis server
+
+```bash
+redis-stream-cli list -u redis://myserver:6379
+```
+
+##### List streams and save to auto-generated file (streams.json)
+
+```bash
+redis-stream-cli list -f
+```
+
+##### List streams and save to a specific file
+
+```bash
+redis-stream-cli list -f my-streams.json
+```
+
+##### Enable debug logging
+
+```bash
+RUST_LOG=debug redis-stream-cli list
+```
+
+#### Output Format
+
+The `list` command outputs a JSON array of stream names, sorted alphabetically:
+
+```json
+[
+  "query:room-comfort:results",
+  "query:test:results",
+  "stream1",
+  "stream2"
+]
+```
+
+## Integration with Drasi Test Infrastructure
 
 This tool can be used to inspect query results from the Drasi test framework, which uses Redis streams to publish query results.
 
 ```bash
+# List all available streams (including query result streams)
+redis-stream-cli list
+
 # Read results from a query stream
-redis-stream-cli -s query:my-query-id:results -f query-results.json
+redis-stream-cli read -s query:my-query-id:results -f query-results.json
 
 # Monitor recent results
-redis-stream-cli -s query:my-query-id:results -t $ -c 100
+redis-stream-cli read -s query:my-query-id:results -t $ -c 100
 ```
 
 ### JSON Parsing

--- a/data-tools/redis/redis-stream-cli/README.md
+++ b/data-tools/redis/redis-stream-cli/README.md
@@ -37,7 +37,10 @@ cargo run -p redis-stream-cli -- [OPTIONS]
   - Use `$` to start from the latest entry
   - Use a specific stream ID like `1234567890-0`
 - `-c, --count <COUNT>`: Number of records to read (default: unlimited)
-- `-f, --file <OUTPUT_FILE>`: Optional output file path (default: console output)
+- `-f, --file [OUTPUT_FILE]`: Write output to file (optional filename)
+  - Without filename: Auto-generates filename from stream name and format (e.g., `my-stream.json`)
+  - With filename: Uses the specified filename (e.g., `-f output.json`)
+  - Omit flag entirely: Outputs to console
 - `-o, --format <FORMAT>`: Output format: `json` or `text` (default: `json`)
 
 ### Examples
@@ -72,13 +75,25 @@ redis-stream-cli -s my-stream -t 1609459200000-0
 redis-stream-cli -s my-stream -t $
 ```
 
-#### Output to a file in JSON format
+#### Auto-generate filename from stream name (creates my-stream.json)
+
+```bash
+redis-stream-cli -s my-stream -f
+```
+
+#### Auto-generate filename with text format (creates my-stream.txt)
+
+```bash
+redis-stream-cli -s my-stream -f -o text
+```
+
+#### Output to a specific file in JSON format
 
 ```bash
 redis-stream-cli -s my-stream -f output.json
 ```
 
-#### Output to a file in text format
+#### Output to a specific file in text format
 
 ```bash
 redis-stream-cli -s my-stream -f output.txt -o text

--- a/data-tools/redis/redis-stream-cli/README.md
+++ b/data-tools/redis/redis-stream-cli/README.md
@@ -1,0 +1,253 @@
+# Redis Stream CLI
+
+A command-line utility for reading records from Redis streams and outputting them to console or file.
+
+## Overview
+
+`redis-stream-cli` is a Rust-based CLI tool that provides an easy way to read and export data from Redis streams. It supports reading from any position in a stream, limiting the number of records, and outputting in multiple formats (JSON or text).
+
+**Key Feature:** Automatically parses JSON in the `data` field, outputting proper JSON objects instead of escaped JSON strings. This makes the output directly usable by JSON processors and easier to read.
+
+## Installation
+
+### Build from Source
+
+```bash
+cd data-tools/redis/redis-stream-cli
+cargo build --release
+```
+
+The binary will be available at `target/release/redis-stream-cli`.
+
+### Running with Cargo
+
+```bash
+cargo run -p redis-stream-cli -- [OPTIONS]
+```
+
+## Usage
+
+### Command Line Arguments
+
+- `-u, --url <REDIS_URL>`: Redis server URL (default: `redis://localhost:6379`)
+  - Can also be set via `REDIS_URL` environment variable
+- `-s, --stream <STREAM_NAME>`: Stream name (required)
+- `-t, --timestamp <START_TIMESTAMP>`: Timestamp to read from (default: `0` for beginning)
+  - Use `0` or `0-0` to start from the beginning
+  - Use `$` to start from the latest entry
+  - Use a specific stream ID like `1234567890-0`
+- `-c, --count <COUNT>`: Number of records to read (default: unlimited)
+- `-f, --file <OUTPUT_FILE>`: Optional output file path (default: console output)
+- `-o, --format <FORMAT>`: Output format: `json` or `text` (default: `json`)
+
+### Examples
+
+#### Read all records from a stream and display as JSON
+
+```bash
+redis-stream-cli -s my-stream
+```
+
+#### Read from a specific Redis server
+
+```bash
+redis-stream-cli -u redis://myserver:6379 -s my-stream
+```
+
+#### Read only 10 records
+
+```bash
+redis-stream-cli -s my-stream -c 10
+```
+
+#### Read from a specific timestamp
+
+```bash
+redis-stream-cli -s my-stream -t 1609459200000-0
+```
+
+#### Read from the latest entries
+
+```bash
+redis-stream-cli -s my-stream -t $
+```
+
+#### Output to a file in JSON format
+
+```bash
+redis-stream-cli -s my-stream -f output.json
+```
+
+#### Output to a file in text format
+
+```bash
+redis-stream-cli -s my-stream -f output.txt -o text
+```
+
+#### Using environment variable for Redis URL
+
+```bash
+export REDIS_URL=redis://myserver:6379
+redis-stream-cli -s my-stream
+```
+
+#### Enable debug logging
+
+```bash
+RUST_LOG=debug redis-stream-cli -s my-stream
+```
+
+### Integration with Drasi Test Infrastructure
+
+This tool can be used to inspect query results from the Drasi test framework, which uses Redis streams to publish query results.
+
+```bash
+# Read results from a query stream
+redis-stream-cli -s query:my-query-id:results -f query-results.json
+
+# Monitor recent results
+redis-stream-cli -s query:my-query-id:results -t $ -c 100
+```
+
+### JSON Parsing
+
+The tool automatically parses the `data` field as JSON when it contains valid JSON. This is particularly useful for Drasi query results where the `data` field contains structured query output.
+
+**Example:**
+If a Redis stream contains:
+```
+data: '{"kind":"control","queryId":"test","sequence":1}'
+```
+
+The output will be:
+```json
+{
+  "fields": {
+    "data": {
+      "kind": "control",
+      "queryId": "test",
+      "sequence": 1
+    }
+  }
+}
+```
+
+If the `data` field is not valid JSON, it will be stored as a string.
+
+## Output Formats
+
+### JSON Format
+
+Records are output as a **JSON array** with proper JSON objects (not JSON strings). The `data` field is automatically parsed if it contains valid JSON:
+
+```json
+[
+  {
+    "id": "1234567890-0",
+    "timestamp_ms": 1234567890,
+    "fields": {
+      "field1": "value1",
+      "field2": "value2"
+    }
+  }
+]
+```
+
+**With parsed JSON data field:**
+
+```json
+[
+  {
+    "id": "1760998189031-0",
+    "timestamp_ms": 1760998189031,
+    "fields": {
+      "data": {
+        "kind": "control",
+        "queryId": "room-comfort-level",
+        "sequence": 1,
+        "sourceTimeMs": 1760998188944,
+        "controlSignal": {
+          "kind": "running"
+        }
+      }
+    }
+  }
+]
+```
+
+**Note:** The output is valid JSON that can be directly parsed by any JSON processor. The `data` field is a JSON object, not a JSON string.
+
+### Text Format
+
+Records are output as human-readable text. JSON objects in the `data` field are pretty-printed:
+
+```
+ID: 1234567890-0
+Timestamp: 1234567890
+Fields:
+  field1: value1
+  field2: value2
+
+---
+ID: 1760998189031-0
+Timestamp: 1760998189031
+Fields:
+  data: {
+  "kind": "control",
+  "queryId": "room-comfort-level",
+  "sequence": 1,
+  "sourceTimeMs": 1760998188944,
+  "controlSignal": {
+    "kind": "running"
+  }
+}
+```
+
+## Error Handling
+
+The tool provides clear error messages for common issues:
+
+- Connection failures to Redis
+- Non-existent streams
+- Invalid stream IDs
+- File write errors
+
+Exit codes:
+- `0`: Success
+- `1`: Error occurred
+
+## Development
+
+### Running Tests
+
+```bash
+cargo test -p redis-stream-cli
+```
+
+### Code Formatting
+
+```bash
+cargo fmt
+```
+
+### Linting
+
+```bash
+cargo clippy
+```
+
+## License
+
+Copyright 2025 The Drasi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/data-tools/redis/redis-stream-cli/src/lib.rs
+++ b/data-tools/redis/redis-stream-cli/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod output;
+pub mod reader;
+pub mod types;

--- a/data-tools/redis/redis-stream-cli/src/main.rs
+++ b/data-tools/redis/redis-stream-cli/src/main.rs
@@ -1,0 +1,67 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::Parser;
+use redis_stream_cli::output::create_writer;
+use redis_stream_cli::reader::RedisStreamReader;
+use redis_stream_cli::types::Params;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let params = Params::parse();
+
+    let res = handle_read_command(params).await;
+
+    match res {
+        Ok(_) => {
+            log::info!("Command completed successfully");
+        }
+        Err(e) => {
+            eprintln!("redis-stream-cli command failed: {:?}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn handle_read_command(params: Params) -> anyhow::Result<()> {
+    log::debug!("Read command:");
+    log::debug!("  Redis URL: {}", params.redis_url);
+    log::debug!("  Stream name: {}", params.stream_name);
+    log::debug!("  Start timestamp: {}", params.start_timestamp);
+    log::debug!("  Count: {:?}", params.count);
+    log::debug!("  Output file: {:?}", params.output_file);
+    log::debug!("  Output format: {:?}", params.output_format);
+
+    // Create the Redis stream reader
+    let mut reader = RedisStreamReader::new(&params.redis_url, params.stream_name.clone()).await?;
+
+    // Read records from the stream
+    let records = reader
+        .read_records(&params.start_timestamp, params.count)
+        .await?;
+
+    log::info!("Successfully read {} records", records.len());
+
+    // Create the appropriate output writer
+    let writer = create_writer(params.output_file);
+
+    // Write the records
+    writer
+        .write_records(&records, &params.output_format)
+        .await?;
+
+    Ok(())
+}

--- a/data-tools/redis/redis-stream-cli/src/main.rs
+++ b/data-tools/redis/redis-stream-cli/src/main.rs
@@ -55,8 +55,16 @@ async fn handle_read_command(params: Params) -> anyhow::Result<()> {
 
     log::info!("Successfully read {} records", records.len());
 
+    // Get the output file path (auto-generated or specified)
+    let output_path = params.get_output_path();
+
+    // Log the output destination
+    if let Some(ref path) = output_path {
+        log::info!("Writing output to file: {:?}", path);
+    }
+
     // Create the appropriate output writer
-    let writer = create_writer(params.output_file);
+    let writer = create_writer(output_path);
 
     // Write the records
     writer

--- a/data-tools/redis/redis-stream-cli/src/main.rs
+++ b/data-tools/redis/redis-stream-cli/src/main.rs
@@ -14,16 +14,19 @@
 
 use clap::Parser;
 use redis_stream_cli::output::create_writer;
-use redis_stream_cli::reader::RedisStreamReader;
-use redis_stream_cli::types::Params;
+use redis_stream_cli::reader::{list_streams, RedisStreamReader};
+use redis_stream_cli::types::{Cli, Commands, ListArgs, ReadArgs};
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
 
-    let params = Params::parse();
+    let cli = Cli::parse();
 
-    let res = handle_read_command(params).await;
+    let res = match cli.command {
+        Commands::Read(args) => handle_read_command(args).await,
+        Commands::List(args) => handle_list_command(args).await,
+    };
 
     match res {
         Ok(_) => {
@@ -36,27 +39,27 @@ async fn main() {
     }
 }
 
-async fn handle_read_command(params: Params) -> anyhow::Result<()> {
+async fn handle_read_command(args: ReadArgs) -> anyhow::Result<()> {
     log::debug!("Read command:");
-    log::debug!("  Redis URL: {}", params.redis_url);
-    log::debug!("  Stream name: {}", params.stream_name);
-    log::debug!("  Start timestamp: {}", params.start_timestamp);
-    log::debug!("  Count: {:?}", params.count);
-    log::debug!("  Output file: {:?}", params.output_file);
-    log::debug!("  Output format: {:?}", params.output_format);
+    log::debug!("  Redis URL: {}", args.redis_url);
+    log::debug!("  Stream name: {}", args.stream_name);
+    log::debug!("  Start timestamp: {}", args.start_timestamp);
+    log::debug!("  Count: {:?}", args.count);
+    log::debug!("  Output file: {:?}", args.output_file);
+    log::debug!("  Output format: {:?}", args.output_format);
 
     // Create the Redis stream reader
-    let mut reader = RedisStreamReader::new(&params.redis_url, params.stream_name.clone()).await?;
+    let mut reader = RedisStreamReader::new(&args.redis_url, args.stream_name.clone()).await?;
 
     // Read records from the stream
     let records = reader
-        .read_records(&params.start_timestamp, params.count)
+        .read_records(&args.start_timestamp, args.count)
         .await?;
 
     log::info!("Successfully read {} records", records.len());
 
     // Get the output file path (auto-generated or specified)
-    let output_path = params.get_output_path();
+    let output_path = args.get_output_path();
 
     // Log the output destination
     if let Some(ref path) = output_path {
@@ -67,9 +70,57 @@ async fn handle_read_command(params: Params) -> anyhow::Result<()> {
     let writer = create_writer(output_path);
 
     // Write the records
-    writer
-        .write_records(&records, &params.output_format)
-        .await?;
+    writer.write_records(&records, &args.output_format).await?;
+
+    Ok(())
+}
+
+async fn handle_list_command(args: ListArgs) -> anyhow::Result<()> {
+    log::debug!("List command:");
+    log::debug!("  Redis URL: {}", args.redis_url);
+    log::debug!("  Output file: {:?}", args.output_file);
+
+    // List all streams
+    let streams = list_streams(&args.redis_url).await?;
+
+    log::info!("Found {} streams", streams.len());
+
+    // Get the output file path (auto-generated or specified)
+    let output_path = args.get_output_path();
+
+    // Log the output destination
+    if let Some(ref path) = output_path {
+        log::info!("Writing output to file: {:?}", path);
+    }
+
+    // Format as JSON
+    let json_output = serde_json::to_string_pretty(&streams)?;
+
+    // Output to console or file
+    match output_path {
+        Some(path) => {
+            // Write to file
+            use tokio::fs::File;
+            use tokio::io::AsyncWriteExt;
+
+            // Ensure parent directory exists
+            if let Some(parent) = path.parent() {
+                if !parent.exists() {
+                    tokio::fs::create_dir_all(parent).await?;
+                }
+            }
+
+            let mut file = File::create(&path).await?;
+            file.write_all(json_output.as_bytes()).await?;
+            file.flush().await?;
+
+            log::info!("Successfully wrote {} streams to file", streams.len());
+        }
+        None => {
+            // Write to console
+            println!("{}", json_output);
+        }
+    }
 
     Ok(())
 }

--- a/data-tools/redis/redis-stream-cli/src/output.rs
+++ b/data-tools/redis/redis-stream-cli/src/output.rs
@@ -1,0 +1,105 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::types::{OutputFormat, StreamRecord};
+use std::path::PathBuf;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+/// Output writer enum that handles both console and file output
+pub enum Writer {
+    Console,
+    File(PathBuf),
+}
+
+impl Writer {
+    /// Write records to the output destination
+    pub async fn write_records(
+        &self,
+        records: &[StreamRecord],
+        format: &OutputFormat,
+    ) -> anyhow::Result<()> {
+        match self {
+            Writer::Console => write_to_console(records, format).await,
+            Writer::File(path) => write_to_file(records, format, path).await,
+        }
+    }
+}
+
+/// Write records to console
+async fn write_to_console(records: &[StreamRecord], format: &OutputFormat) -> anyhow::Result<()> {
+    match format {
+        OutputFormat::Json => {
+            // Output as a JSON array
+            let json = serde_json::to_string_pretty(&records)?;
+            println!("{}", json);
+        }
+        OutputFormat::Text => {
+            // Output each record as text
+            for (i, record) in records.iter().enumerate() {
+                if i > 0 {
+                    println!("\n---");
+                }
+                println!("{}", record.to_text());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Write records to a file
+async fn write_to_file(
+    records: &[StreamRecord],
+    format: &OutputFormat,
+    path: &PathBuf,
+) -> anyhow::Result<()> {
+    let content = match format {
+        OutputFormat::Json => serde_json::to_string_pretty(&records)?,
+        OutputFormat::Text => {
+            let mut lines = Vec::new();
+            for (i, record) in records.iter().enumerate() {
+                if i > 0 {
+                    lines.push("\n---".to_string());
+                }
+                lines.push(record.to_text());
+            }
+            lines.join("\n")
+        }
+    };
+
+    log::info!("Writing output to file: {:?}", path);
+
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+    }
+
+    let mut file = File::create(path).await?;
+    file.write_all(content.as_bytes()).await?;
+    file.flush().await?;
+
+    log::info!("Successfully wrote {} records to file", records.len());
+
+    Ok(())
+}
+
+/// Create an output writer based on the output file option
+pub fn create_writer(output_file: Option<PathBuf>) -> Writer {
+    match output_file {
+        Some(path) => Writer::File(path),
+        None => Writer::Console,
+    }
+}

--- a/data-tools/redis/redis-stream-cli/src/reader.rs
+++ b/data-tools/redis/redis-stream-cli/src/reader.rs
@@ -143,3 +143,34 @@ impl RedisStreamReader {
         Ok(all_records)
     }
 }
+
+/// List all stream names on a Redis server
+pub async fn list_streams(redis_url: &str) -> anyhow::Result<Vec<String>> {
+    use redis::AsyncCommands;
+
+    log::info!("Connecting to Redis at: {}", redis_url);
+    let client = Client::open(redis_url)?;
+    let mut connection = client.get_multiplexed_async_connection().await?;
+    log::info!("Successfully connected to Redis");
+
+    log::debug!("Scanning for streams using TYPE filter");
+
+    let mut stream_names: Vec<String> = Vec::new();
+
+    // Use SCAN with TYPE option (requires Redis 6.0+)
+    // SCAN is cursor-based and safe for production use
+    let opts = redis::ScanOptions::default().with_type("stream");
+
+    let mut scan_iter: redis::AsyncIter<String> = connection.scan_options(opts).await?;
+
+    while let Some(key) = scan_iter.next_item().await {
+        log::debug!("Found stream: {}", key);
+        stream_names.push(key);
+    }
+
+    // Sort for consistent output
+    stream_names.sort();
+
+    log::info!("Found {} streams", stream_names.len());
+    Ok(stream_names)
+}

--- a/data-tools/redis/redis-stream-cli/src/reader.rs
+++ b/data-tools/redis/redis-stream-cli/src/reader.rs
@@ -1,0 +1,145 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::types::StreamRecord;
+use redis::{streams::StreamRangeReply, AsyncCommands, Client};
+use std::collections::HashMap;
+
+/// Redis stream reader for reading records from a stream
+pub struct RedisStreamReader {
+    connection: redis::aio::MultiplexedConnection,
+    stream_name: String,
+}
+
+impl RedisStreamReader {
+    /// Create a new RedisStreamReader
+    ///
+    /// # Arguments
+    /// * `redis_url` - The Redis server URL (e.g., "redis://localhost:6379")
+    /// * `stream_name` - The name of the stream to read from
+    pub async fn new(redis_url: &str, stream_name: String) -> anyhow::Result<Self> {
+        log::info!("Connecting to Redis at: {}", redis_url);
+        let client = Client::open(redis_url)?;
+        let connection = client.get_multiplexed_async_connection().await?;
+        log::info!("Successfully connected to Redis");
+
+        Ok(Self {
+            connection,
+            stream_name,
+        })
+    }
+
+    /// Read records from the stream
+    ///
+    /// # Arguments
+    /// * `start_id` - The stream ID to start reading from (e.g., "0", "0-0", "$", or a specific ID)
+    /// * `count` - Optional maximum number of records to read
+    ///
+    /// # Returns
+    /// A vector of StreamRecord objects
+    pub async fn read_records(
+        &mut self,
+        start_id: &str,
+        count: Option<usize>,
+    ) -> anyhow::Result<Vec<StreamRecord>> {
+        log::info!(
+            "Reading from stream '{}' starting at ID '{}'",
+            self.stream_name,
+            start_id
+        );
+
+        let mut all_records = Vec::new();
+        // For XRANGE, use "-" to start from the beginning instead of "0"
+        let mut current_id = if start_id == "0" || start_id == "0-0" {
+            "-".to_string()
+        } else {
+            start_id.to_string()
+        };
+        let remaining_count = count;
+
+        // If we have a count limit, we'll read in batches
+        let batch_size = count.unwrap_or(100);
+
+        loop {
+            log::debug!("Executing XRANGE from ID: {}", current_id);
+
+            // Use XRANGE for reading historical data from the beginning
+            // xrange returns StreamRangeReply which contains the IDs
+            let result: StreamRangeReply = self
+                .connection
+                .xrange_count(&self.stream_name, &current_id, "+", batch_size)
+                .await?;
+
+            let ids = result.ids;
+
+            if ids.is_empty() {
+                log::debug!("No more records found in stream");
+                break;
+            }
+
+            let mut batch_count = 0;
+
+            for stream_id in ids {
+                let id = stream_id.id;
+                let mut fields = HashMap::new();
+
+                // Convert the stream entry fields to a HashMap
+                for (key, value) in stream_id.map {
+                    if let redis::Value::BulkString(bytes) = value {
+                        let value_str = String::from_utf8_lossy(&bytes).to_string();
+                        fields.insert(key, value_str);
+                    } else {
+                        // Handle other value types by converting to string
+                        fields.insert(key, format!("{:?}", value));
+                    }
+                }
+
+                all_records.push(StreamRecord::new(id.clone(), fields));
+
+                // Update current_id for next iteration - need to go past this ID
+                // For XRANGE, we use "(" prefix to mean exclusive
+                current_id = format!("({}", id);
+                batch_count += 1;
+
+                // Check if we've reached the count limit
+                if let Some(limit) = remaining_count {
+                    if all_records.len() >= limit {
+                        log::info!("Reached count limit of {} records", limit);
+                        return Ok(all_records);
+                    }
+                }
+            }
+
+            // If we got fewer records than the batch size, we've reached the end
+            if batch_count < batch_size {
+                log::debug!(
+                    "Reached end of stream (got {} records in batch)",
+                    batch_count
+                );
+                break;
+            }
+
+            // If no count limit, read another batch
+            if let Some(limit) = count {
+                // With a count limit, check if we should continue
+                if all_records.len() >= limit {
+                    break;
+                }
+            }
+        }
+
+        log::info!("Read {} total records from stream", all_records.len());
+        Ok(all_records)
+    }
+}

--- a/data-tools/redis/redis-stream-cli/src/types.rs
+++ b/data-tools/redis/redis-stream-cli/src/types.rs
@@ -12,16 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::{Parser, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// CLI parameters for the redis-stream-cli utility
+/// CLI for working with Redis streams
 #[derive(Parser, Debug)]
 #[command(name = "redis-stream-cli")]
-#[command(about = "CLI for reading records from Redis streams", long_about = None)]
-pub struct Params {
+#[command(about = "CLI for working with Redis streams", long_about = None)]
+#[command(version)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Available subcommands
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Read records from a Redis stream
+    Read(ReadArgs),
+    /// List all stream names on a Redis server
+    List(ListArgs),
+}
+
+/// Arguments for the read subcommand
+#[derive(Args, Debug)]
+pub struct ReadArgs {
     /// Redis server URL
     #[arg(
         short = 'u',
@@ -53,7 +70,7 @@ pub struct Params {
     pub output_format: OutputFormat,
 }
 
-impl Params {
+impl ReadArgs {
     /// Get the output file path, generating one if -f was used without a value
     pub fn get_output_path(&self) -> Option<PathBuf> {
         self.output_file.as_ref().map(|f| {
@@ -64,6 +81,37 @@ impl Params {
                     OutputFormat::Text => "txt",
                 };
                 PathBuf::from(format!("{}.{}", self.stream_name, extension))
+            } else {
+                PathBuf::from(f)
+            }
+        })
+    }
+}
+
+/// Arguments for the list subcommand
+#[derive(Args, Debug)]
+pub struct ListArgs {
+    /// Redis server URL
+    #[arg(
+        short = 'u',
+        long = "url",
+        env = "REDIS_URL",
+        default_value = "redis://localhost:6379"
+    )]
+    pub redis_url: String,
+
+    /// Write output to file. If no filename provided, uses "streams.json"
+    /// Example: -f (creates streams.json), -f myfile.json (uses specified name)
+    #[arg(short = 'f', long = "file", num_args = 0..=1, default_missing_value = "")]
+    pub output_file: Option<String>,
+}
+
+impl ListArgs {
+    /// Get the output file path, generating "streams.json" if -f was used without a value
+    pub fn get_output_path(&self) -> Option<PathBuf> {
+        self.output_file.as_ref().map(|f| {
+            if f.is_empty() {
+                PathBuf::from("streams.json")
             } else {
                 PathBuf::from(f)
             }

--- a/data-tools/redis/redis-stream-cli/src/types.rs
+++ b/data-tools/redis/redis-stream-cli/src/types.rs
@@ -1,0 +1,138 @@
+// Copyright 2025 The Drasi Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::{Parser, ValueEnum};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// CLI parameters for the redis-stream-cli utility
+#[derive(Parser, Debug)]
+#[command(name = "redis-stream-cli")]
+#[command(about = "CLI for reading records from Redis streams", long_about = None)]
+pub struct Params {
+    /// Redis server URL
+    #[arg(
+        short = 'u',
+        long = "url",
+        env = "REDIS_URL",
+        default_value = "redis://localhost:6379"
+    )]
+    pub redis_url: String,
+
+    /// Stream name (mandatory)
+    #[arg(short = 's', long = "stream")]
+    pub stream_name: String,
+
+    /// Timestamp to read from (default: 0 for beginning, use $ for latest)
+    #[arg(short = 't', long = "timestamp", default_value = "0")]
+    pub start_timestamp: String,
+
+    /// Number of records to read (default: unlimited)
+    #[arg(short = 'c', long = "count")]
+    pub count: Option<usize>,
+
+    /// Optional output file (default: console output)
+    #[arg(short = 'f', long = "file")]
+    pub output_file: Option<PathBuf>,
+
+    /// Output format (json or text)
+    #[arg(short = 'o', long = "format", default_value = "json")]
+    pub output_format: OutputFormat,
+}
+
+/// Output format options
+#[derive(Clone, Debug, ValueEnum)]
+pub enum OutputFormat {
+    /// JSON format with pretty printing
+    Json,
+    /// Plain text format
+    Text,
+}
+
+/// Represents a single record from a Redis stream
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamRecord {
+    /// The Redis stream ID (e.g., "1234567890-0")
+    pub id: String,
+    /// Timestamp in milliseconds extracted from the stream ID
+    pub timestamp_ms: u64,
+    /// The field-value pairs from the stream entry
+    /// Values are either strings or parsed JSON objects
+    pub fields: HashMap<String, serde_json::Value>,
+}
+
+impl StreamRecord {
+    /// Create a new StreamRecord from a Redis stream ID and field map
+    /// Attempts to parse the "data" field as JSON if present
+    pub fn new(id: String, fields: HashMap<String, String>) -> Self {
+        // Extract timestamp from the stream ID (format: "timestamp-sequence")
+        let timestamp_ms = id
+            .split('-')
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        // Convert fields to serde_json::Value, parsing "data" field as JSON if possible
+        let mut parsed_fields = HashMap::new();
+        for (key, value) in fields {
+            if key == "data" {
+                // Try to parse as JSON
+                match serde_json::from_str::<serde_json::Value>(&value) {
+                    Ok(json_value) => {
+                        parsed_fields.insert(key, json_value);
+                    }
+                    Err(_) => {
+                        // If parsing fails, store as string
+                        parsed_fields.insert(key, serde_json::Value::String(value));
+                    }
+                }
+            } else {
+                // For non-data fields, store as string
+                parsed_fields.insert(key, serde_json::Value::String(value));
+            }
+        }
+
+        Self {
+            id,
+            timestamp_ms,
+            fields: parsed_fields,
+        }
+    }
+
+    /// Format the record as JSON
+    pub fn to_json(&self) -> anyhow::Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+
+    /// Format the record as plain text
+    pub fn to_text(&self) -> String {
+        let mut lines = vec![
+            format!("ID: {}", self.id),
+            format!("Timestamp: {}", self.timestamp_ms),
+            "Fields:".to_string(),
+        ];
+
+        for (key, value) in &self.fields {
+            // Format value based on its type
+            let value_str = match value {
+                serde_json::Value::String(s) => s.clone(),
+                _ => serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()),
+            };
+            lines.push(format!("  {}: {}", key, value_str));
+        }
+
+        lines.join("\n")
+    }
+}

--- a/data-tools/redis/redis-stream-cli/src/types.rs
+++ b/data-tools/redis/redis-stream-cli/src/types.rs
@@ -43,13 +43,32 @@ pub struct Params {
     #[arg(short = 'c', long = "count")]
     pub count: Option<usize>,
 
-    /// Optional output file (default: console output)
-    #[arg(short = 'f', long = "file")]
-    pub output_file: Option<PathBuf>,
+    /// Write output to file. If no filename provided, uses stream name with appropriate extension.
+    /// Example: -f (auto-generates filename), -f myfile.json (uses specified name)
+    #[arg(short = 'f', long = "file", num_args = 0..=1, default_missing_value = "")]
+    pub output_file: Option<String>,
 
     /// Output format (json or text)
     #[arg(short = 'o', long = "format", default_value = "json")]
     pub output_format: OutputFormat,
+}
+
+impl Params {
+    /// Get the output file path, generating one if -f was used without a value
+    pub fn get_output_path(&self) -> Option<PathBuf> {
+        self.output_file.as_ref().map(|f| {
+            if f.is_empty() {
+                // Generate filename from stream name and format
+                let extension = match self.output_format {
+                    OutputFormat::Json => "json",
+                    OutputFormat::Text => "txt",
+                };
+                PathBuf::from(format!("{}.{}", self.stream_name, extension))
+            } else {
+                PathBuf::from(f)
+            }
+        })
+    }
 }
 
 /// Output format options


### PR DESCRIPTION
This pull request introduces a new Rust CLI tool for generating fictional Azure Resource Notification (ARN) test data, which is intended for Drasi testing and integration scenarios. The main changes include the creation of the ARN data generator's core modules, its configuration and resource generation logic, and comprehensive documentation on usage and output formats.

Key changes:

**New CLI Tool and Documentation**
- Added a detailed `README.md` describing the ARN test data generator, its purpose, usage instructions, supported notification formats, output structure, and example commands. This documentation guides users on generating various types of test datasets for different scenarios.

**Core Generator Implementation**
- Introduced the `ArnDataGenerator` struct and its associated methods in `generator.rs`, enabling generation of management groups (with hierarchical relationships), service groups, relationships, and change events (inserts and updates) with realistic randomization and time-based properties.
- Defined the `GeneratorConfig` struct for configuring the generator with options such as counts, hierarchy depth, tenant ID, and start time.

**Module Structure and Exports**
- Created the `arn` module (`mod.rs`), exposing the generator and model types for use by the CLI and other consumers. This establishes the code structure for the ARN data generator package.

**Project Setup**
- Added a new `Cargo.toml` specifying dependencies (such as `chrono`, `clap`, `serde`, `tokio`, `uuid`, etc.) and linking to the shared test data store, enabling compilation and integration with the broader project.