### PR TITLE
Add on-demand E2E runs against an arbitrary drasi-server branch/fork (building_comfort + stock_market)

### DIFF
--- a/.github/workflows/e2e-building-comfort.yml
+++ b/.github/workflows/e2e-building-comfort.yml
@@ -14,16 +14,12 @@ name: E2E - building_comfort
 on:
   workflow_dispatch:
     inputs:
-      drasi_server_version:
-        description: "drasi-server release tag (e.g. v0.1.5). Empty = latest. Ignored when drasi_server_ref is set."
-        required: false
-        default: ""
       drasi_server_repo:
-        description: "drasi-server repo (owner/name) to build from. Use a fork here. Only applies when drasi_server_ref is set."
+        description: "drasi-server repo (owner/name) to build from. Default: drasi-project/drasi-server."
         required: false
         default: "drasi-project/drasi-server"
       drasi_server_ref:
-        description: "drasi-server branch/tag/SHA to BUILD from source (http/grpc jobs). Empty = download the release binary."
+        description: "drasi-server branch/tag/SHA to BUILD from source (http/grpc jobs). Empty = download the latest release binary."
         required: false
         default: ""
       timeout_minutes:
@@ -44,10 +40,9 @@ jobs:
     timeout-minutes: 60
     env:
       WORKDIR: e2e-test-framework/examples/building_comfort/ci/drasi_server_http
-      DRASI_SERVER_VERSION: ${{ inputs.drasi_server_version }}
       # When drasi_server_ref is set, the runner builds drasi-server from that
       # branch/tag/SHA of DRASI_REPO (a fork if drasi_server_repo points at one)
-      # instead of downloading a release.
+      # instead of downloading the latest release.
       DRASI_REPO: ${{ inputs.drasi_server_repo }}
       DRASI_SERVER_REF: ${{ inputs.drasi_server_ref }}
       # Determinism baselines live inline in $WORKDIR/config.json under the
@@ -113,10 +108,9 @@ jobs:
     timeout-minutes: 60
     env:
       WORKDIR: e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc
-      DRASI_SERVER_VERSION: ${{ inputs.drasi_server_version }}
       # When drasi_server_ref is set, the runner builds drasi-server from that
       # branch/tag/SHA of DRASI_REPO (a fork if drasi_server_repo points at one)
-      # instead of downloading a release.
+      # instead of downloading the latest release.
       DRASI_REPO: ${{ inputs.drasi_server_repo }}
       DRASI_SERVER_REF: ${{ inputs.drasi_server_ref }}
       # Determinism baselines live inline in $WORKDIR/config.json under the

--- a/.github/workflows/e2e-building-comfort.yml
+++ b/.github/workflows/e2e-building-comfort.yml
@@ -15,9 +15,9 @@ on:
   workflow_dispatch:
     inputs:
       drasi_server_repo:
-        description: "drasi-server repo (owner/name) to build from. Default: drasi-project/drasi-server."
+        description: "drasi-server repo (owner/name) to build from. Empty defaults to drasi-project/drasi-server."
         required: false
-        default: "drasi-project/drasi-server"
+        default: ""
       drasi_server_ref:
         description: "drasi-server branch/tag/SHA to BUILD from source (http/grpc jobs). Empty = download the latest release binary."
         required: false

--- a/.github/workflows/e2e-building-comfort.yml
+++ b/.github/workflows/e2e-building-comfort.yml
@@ -15,7 +15,15 @@ on:
   workflow_dispatch:
     inputs:
       drasi_server_version:
-        description: "drasi-server release tag (e.g. v0.1.5). Empty = latest."
+        description: "drasi-server release tag (e.g. v0.1.5). Empty = latest. Ignored when drasi_server_ref is set."
+        required: false
+        default: ""
+      drasi_server_repo:
+        description: "drasi-server repo (owner/name) to build from. Use a fork here. Only applies when drasi_server_ref is set."
+        required: false
+        default: "drasi-project/drasi-server"
+      drasi_server_ref:
+        description: "drasi-server branch/tag/SHA to BUILD from source (http/grpc jobs). Empty = download the release binary."
         required: false
         default: ""
       timeout_minutes:
@@ -37,6 +45,11 @@ jobs:
     env:
       WORKDIR: e2e-test-framework/examples/building_comfort/ci/drasi_server_http
       DRASI_SERVER_VERSION: ${{ inputs.drasi_server_version }}
+      # When drasi_server_ref is set, the runner builds drasi-server from that
+      # branch/tag/SHA of DRASI_REPO (a fork if drasi_server_repo points at one)
+      # instead of downloading a release.
+      DRASI_REPO: ${{ inputs.drasi_server_repo }}
+      DRASI_SERVER_REF: ${{ inputs.drasi_server_ref }}
       # Determinism baselines live inline in $WORKDIR/config.json under the
       # Sha256Determinism completion handler's `expected` map. The framework
       # flips the test-run status to Error on mismatch; the runner script
@@ -101,6 +114,11 @@ jobs:
     env:
       WORKDIR: e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc
       DRASI_SERVER_VERSION: ${{ inputs.drasi_server_version }}
+      # When drasi_server_ref is set, the runner builds drasi-server from that
+      # branch/tag/SHA of DRASI_REPO (a fork if drasi_server_repo points at one)
+      # instead of downloading a release.
+      DRASI_REPO: ${{ inputs.drasi_server_repo }}
+      DRASI_SERVER_REF: ${{ inputs.drasi_server_ref }}
       # Determinism baselines live inline in $WORKDIR/config.json under the
       # Sha256Determinism completion handler's `expected` map. First run
       # uses missing_baseline=Warn so the framework just logs the actual

--- a/.github/workflows/e2e-stock-market-join.yml
+++ b/.github/workflows/e2e-stock-market-join.yml
@@ -12,8 +12,12 @@ name: E2E - stock_market join
 on:
   workflow_dispatch:
     inputs:
-      drasi_server_version:
-        description: "drasi-server release tag (e.g. v0.1.5). Empty = latest."
+      drasi_server_repo:
+        description: "drasi-server repo (owner/name) to build from. Empty defaults to drasi-project/drasi-server."
+        required: false
+        default: ""
+      drasi_server_ref:
+        description: "drasi-server branch/tag/SHA to BUILD from source. Empty = download the latest release binary."
         required: false
         default: ""
       timeout_minutes:
@@ -34,7 +38,11 @@ jobs:
     timeout-minutes: 60
     env:
       WORKDIR: e2e-test-framework/examples/stock_market/ci/drasi_server_http_grpc_join
-      DRASI_SERVER_VERSION: ${{ inputs.drasi_server_version }}
+      # When drasi_server_ref is set, the runner builds drasi-server from that
+      # branch/tag/SHA of DRASI_REPO (a fork if drasi_server_repo points at one)
+      # instead of downloading the latest release.
+      DRASI_REPO: ${{ inputs.drasi_server_repo }}
+      DRASI_SERVER_REF: ${{ inputs.drasi_server_ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/e2e-test-framework/Cargo.toml
+++ b/e2e-test-framework/Cargo.toml
@@ -45,3 +45,17 @@ lto = true
 # drasi-bootstrap-application = { path = "../../drasi-core/components/bootstrappers/application" }
 # drasi-reaction-application = { path = "../../drasi-core/components/reactions/application" }
 # drasi-source-application = { path = "../../drasi-core/components/sources/application" }
+#
+# CI / branch testing: to run the embedded drasi-lib (drasi_lib) variant against
+# a branch or fork of drasi-core, use git patches instead of paths and commit
+# them to your branch. The scheduled workflow (or a workflow_dispatch run against
+# your branch) then builds the test-service with these overrides. Set `branch`
+# (or `rev`/`tag`) and `git` (a fork URL to test a fork). The referenced crate
+# versions must stay semver-compatible with what the workspace requires.
+# [patch.crates-io]
+# drasi-core = { git = "https://github.com/drasi-project/drasi-core", branch = "my-branch" }
+# drasi-lib = { git = "https://github.com/drasi-project/drasi-core", branch = "my-branch" }
+# drasi-bootstrap-noop = { git = "https://github.com/drasi-project/drasi-core", branch = "my-branch" }
+# drasi-bootstrap-application = { git = "https://github.com/drasi-project/drasi-core", branch = "my-branch" }
+# drasi-reaction-application = { git = "https://github.com/drasi-project/drasi-core", branch = "my-branch" }
+# drasi-source-application = { git = "https://github.com/drasi-project/drasi-core", branch = "my-branch" }

--- a/e2e-test-framework/examples/building_comfort/ci/README.md
+++ b/e2e-test-framework/examples/building_comfort/ci/README.md
@@ -1,0 +1,97 @@
+# Building Comfort &mdash; CI E2E tests
+
+This folder holds the CI variants of the `building_comfort` scenario. They are
+driven by the [`E2E - building_comfort`](../../../../.github/workflows/e2e-building-comfort.yml)
+GitHub Actions workflow, which runs three jobs:
+
+| Job | Folder | Transport to Drasi |
+| --- | --- | --- |
+| `building_comfort / drasi_server_http` | [`drasi_server_http`](drasi_server_http) | external drasi-server over HTTP webhooks |
+| `building_comfort / drasi_server_grpc` | [`drasi_server_grpc`](drasi_server_grpc) | external drasi-server over gRPC |
+| `building_comfort / drasi_lib` | [`drasi_lib`](drasi_lib) | drasi-lib embedded in-process |
+
+Each job runs the `run_test_ci.sh` in its folder, which builds the test-service,
+drives change events, waits for the determinism/completion signal, and uploads
+artifacts.
+
+## When it runs
+
+- **Scheduled:** daily at 07:00 UTC. Scheduled runs always download the **latest
+  `drasi-project/drasi-server` release** for the http/grpc jobs.
+- **Manually:** via *Actions → E2E - building_comfort → Run workflow*.
+
+## Triggering a run
+
+1. Go to the repo's **Actions** tab and select **E2E - building_comfort**.
+2. Click **Run workflow**.
+3. Under **Use workflow from**, pick the branch whose workflow + runner scripts
+   you want to use (usually `main`).
+4. Fill in the inputs (all optional) and click **Run workflow**.
+
+### Inputs
+
+| Input | Default | Effect |
+| --- | --- | --- |
+| `drasi_server_repo` | empty | drasi-server repo (`owner/name`) to build from. Empty falls back to `drasi-project/drasi-server`. Only used when `drasi_server_ref` is set. |
+| `drasi_server_ref` | empty | drasi-server branch/tag/SHA to **build from source** (http/grpc jobs). Empty = download the latest release binary. |
+| `timeout_minutes` | 30 | Max minutes to wait for each test to finish. |
+
+### Default run (latest release)
+
+Leave every input empty and click **Run workflow**. The http/grpc jobs download
+the latest `drasi-project/drasi-server` release and test against it &mdash; same
+as the scheduled run.
+
+### Test a drasi-server branch or fork
+
+Set `drasi_server_ref` (and optionally `drasi_server_repo` for a fork). The
+http/grpc runners then `git clone` that repo/ref and `cargo build --release`
+instead of downloading a release.
+
+Example &mdash; test branch `my-branch` on a fork:
+
+- `drasi_server_repo` = `my-user/drasi-server`
+- `drasi_server_ref` = `my-branch`
+
+Or with the CLI:
+
+```bash
+gh workflow run e2e-building-comfort.yml \
+  --ref main \
+  -f drasi_server_repo=my-user/drasi-server \
+  -f drasi_server_ref=my-branch \
+  -f timeout_minutes=45
+```
+
+Requirements:
+
+- The branch/tag/SHA must be **pushed** to the target repo.
+- The repo must be **public** (the runner clones anonymously).
+- The first source build is uncached, so it runs longer &mdash; bump
+  `timeout_minutes` if a run times out.
+
+The `drasi_lib` job ignores these inputs (it has no external binary); see below.
+
+### Test a drasi-core branch (drasi_lib job)
+
+The `drasi_lib` variant compiles drasi-core / drasi-lib **into** the
+test-service, so there is no binary to point at a branch. Instead, override the
+crate sources via Cargo and run the workflow from your branch:
+
+1. On your branch of this repo, add a git-based `[patch.crates-io]` block in
+   [`e2e-test-framework/Cargo.toml`](../../../Cargo.toml) pointing the
+   drasi-core crates at your branch/fork of `drasi-core`.
+2. Push the branch, then run the workflow with **Use workflow from** set to that
+   branch. Cargo pulls the patched sources when it builds the test-service.
+
+See [`drasi_lib/README.md`](drasi_lib/README.md) for the full walkthrough.
+
+## Reading results
+
+- **Step summary:** each http/grpc run labels its drasi-server source as
+  `source <repo>@<ref> (<sha>)` or `release <tag> (<repo>)`, followed by a table
+  of reaction status, record counts, runtimes, SHA-256s, and the determinism
+  verdict.
+- **Artifacts:** every job uploads a `building_comfort-<variant>` artifact with
+  logs, per-reaction final states, performance metrics, and the determinism
+  verdict for offline inspection.

--- a/e2e-test-framework/examples/building_comfort/ci/drasi_lib/README.md
+++ b/e2e-test-framework/examples/building_comfort/ci/drasi_lib/README.md
@@ -56,6 +56,26 @@ Add a job to `.github/workflows/e2e-building-comfort.yml` that points
 `WORKDIR` at this folder; copy the existing `building-comfort-drasi-server-*`
 jobs and drop their drasi-server-specific steps if you want.
 
+### Targeting a drasi-core branch or fork
+
+Unlike the `drasi_server_http` / `drasi_server_grpc` variants (which build an
+external drasi-server binary), this variant compiles drasi-core / drasi-lib
+**into** the test-service. There is no separate binary to point at a branch, so
+the source override is the developer's responsibility via Cargo:
+
+1. On your branch of this repo, uncomment the git-based `[patch.crates-io]`
+   block in [`e2e-test-framework/Cargo.toml`](../../../../Cargo.toml) and set
+   the `branch` (or `rev`/`tag`) and `git` URL (a fork URL to test a fork) for
+   the drasi-core crates.
+2. Commit and push that branch.
+3. Run the workflow *from that branch* (*Actions → E2E - building_comfort →
+   Run workflow → Use workflow from: your-branch*). GitHub checks out the
+   selected branch, so Cargo pulls the patched drasi-core sources when it
+   builds the test-service — no workflow inputs are needed for this variant.
+
+The referenced crate versions must stay semver-compatible with what the
+workspace requires, otherwise Cargo rejects the patch (a useful signal).
+
 ## Run it locally
 
 ```bash

--- a/e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc/README.md
+++ b/e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc/README.md
@@ -82,24 +82,13 @@ export WORK_DIR="$PWD/.local_run/work"
 | Test service gRPC reaction handler (per-room)      | 50052           |
 | Test service gRPC reaction handler (floor-agg)     | 50053           |
 
-## Running in CI against a drasi-server branch or fork
+## Running in CI
 
-The scheduled workflow ([`.github/workflows/e2e-building-comfort.yml`](../../../../../.github/workflows/e2e-building-comfort.yml))
-downloads the latest drasi-server release by default. To instead **build
-drasi-server from source** for this job, run it via *Actions → E2E -
-building_comfort → Run workflow* and set:
-
-- `drasi_server_ref` &mdash; a branch, tag, or commit SHA to build. Leaving
-  it empty keeps the default release-download behavior.
-- `drasi_server_repo` &mdash; the repo to build from (`owner/name`). Point it
-  at a fork to test a fork branch. Defaults to `drasi-project/drasi-server`.
-
-The runner (`run_test_ci.sh`) clones that repo/ref and runs
-`cargo build --release`, then uses the freshly built binary. The workflow
-step summary labels the run with the resolved source
-(`source <repo>@<ref> (<sha>)` or `release <tag> (<repo>)`) so results are
-traceable. The same behavior is available locally by exporting
-`DRASI_SERVER_REF` (and optionally `DRASI_REPO`) before running the script.
+This variant runs as the `building_comfort / drasi_server_grpc` job of the
+`E2E - building_comfort` workflow, which downloads the latest drasi-server
+release by default or builds from a branch/fork on demand. See
+[`../README.md`](../README.md) for how to trigger it and pass a
+`drasi_server_ref` / `drasi_server_repo`.
 
 ## Troubleshooting
 

--- a/e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc/README.md
+++ b/e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc/README.md
@@ -82,6 +82,25 @@ export WORK_DIR="$PWD/.local_run/work"
 | Test service gRPC reaction handler (per-room)      | 50052           |
 | Test service gRPC reaction handler (floor-agg)     | 50053           |
 
+## Running in CI against a drasi-server branch or fork
+
+The scheduled workflow ([`.github/workflows/e2e-building-comfort.yml`](../../../../../.github/workflows/e2e-building-comfort.yml))
+downloads the latest drasi-server release by default. To instead **build
+drasi-server from source** for this job, run it via *Actions → E2E -
+building_comfort → Run workflow* and set:
+
+- `drasi_server_ref` &mdash; a branch, tag, or commit SHA to build. Leaving
+  it empty keeps the default release-download behavior.
+- `drasi_server_repo` &mdash; the repo to build from (`owner/name`). Point it
+  at a fork to test a fork branch. Defaults to `drasi-project/drasi-server`.
+
+The runner (`run_test_ci.sh`) clones that repo/ref and runs
+`cargo build --release`, then uses the freshly built binary. The workflow
+step summary labels the run with the resolved source
+(`source <repo>@<ref> (<sha>)` or `release <tag> (<repo>)`) so results are
+traceable. The same behavior is available locally by exporting
+`DRASI_SERVER_REF` (and optionally `DRASI_REPO`) before running the script.
+
 ## Troubleshooting
 
 - **`address already in use`** &mdash; one of the four ports above is held

--- a/e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc/run_test_ci.sh
+++ b/e2e-test-framework/examples/building_comfort/ci/drasi_server_grpc/run_test_ci.sh
@@ -10,8 +10,9 @@
 # Scheduled / CI runner for the building_comfort / drasi_server_grpc E2E test.
 #
 # Responsibilities:
-#   1. Download the latest (or pinned) drasi-server release binary, unless
-#      DRASI_SERVER_BIN is already set.
+#   1. Obtain the drasi-server binary: download a release, build from a
+#      branch/tag/SHA ($DRASI_SERVER_REF) of $DRASI_REPO, or use a pre-set
+#      DRASI_SERVER_BIN.
 #   2. Patch the example configs so the run is CI-safe (port collision, keep
 #      artifacts on shutdown).
 #   3. Start drasi-server and the test-service as background processes.
@@ -22,9 +23,15 @@
 # or `curl` is used to fetch the release.
 #
 # Environment variables (with defaults):
-#   DRASI_REPO            GitHub repo for releases. Default: drasi-project/drasi-server
-#   DRASI_SERVER_VERSION  Release tag to download. Default: latest
-#   DRASI_SERVER_BIN      Pre-downloaded binary; skips the download step.
+#   DRASI_REPO            GitHub repo (owner/name) for the release download or
+#                         the source build. Default: drasi-project/drasi-server.
+#                         Point at a fork (e.g. myuser/drasi-server) to build a
+#                         fork branch.
+#   DRASI_SERVER_VERSION  Release tag to download. Default: latest (release mode).
+#   DRASI_SERVER_REF      Branch/tag/SHA to BUILD drasi-server from source with
+#                         cargo. When set, overrides the release download.
+#                         Empty = download the release binary (default).
+#   DRASI_SERVER_BIN      Pre-built binary; skips both download and source build.
 #   DRASI_ADMIN_PORT      Admin port to patch into drasi_server_config.yaml. Default: 8090
 #   DRASI_SOURCE_PORT     gRPC source port. Default: 50051
 #   TEST_SERVICE_PORT     test-service REST API port. Default: 63123
@@ -48,6 +55,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 DRASI_REPO="${DRASI_REPO:-drasi-project/drasi-server}"
 DRASI_SERVER_VERSION="${DRASI_SERVER_VERSION:-}"
+DRASI_SERVER_REF="${DRASI_SERVER_REF:-}"
 DRASI_ADMIN_PORT="${DRASI_ADMIN_PORT:-8090}"
 DRASI_SOURCE_PORT="${DRASI_SOURCE_PORT:-50051}"
 TEST_SERVICE_PORT="${TEST_SERVICE_PORT:-63123}"
@@ -60,6 +68,7 @@ WORK_DIR="${WORK_DIR:-$SCRIPT_DIR/.ci_work}"
 
 LOG_DIR="$WORK_DIR/logs"
 DOWNLOAD_DIR="$WORK_DIR/drasi-server-download"
+SRC_BUILD_DIR="$WORK_DIR/drasi-server-src"
 DATA_CACHE="$WORK_DIR/test_data_cache"
 DRASI_CFG_SRC="$SCRIPT_DIR/drasi_server_config.yaml"
 TEST_CFG_SRC="$SCRIPT_DIR/config.json"
@@ -70,6 +79,9 @@ mkdir -p "$WORK_DIR" "$LOG_DIR" "$ARTIFACTS_DIR"
 
 DRASI_PID=""
 SERVICE_PID=""
+# Human-readable description of where DRASI_SERVER_BIN came from (release tag,
+# source build, or preset). Surfaced in the step summary for result labeling.
+DRASI_BUILD_SOURCE=""
 
 log() { echo "[ci] $*"; }
 
@@ -113,9 +125,60 @@ wait_for_port() {
 download_drasi_server() {
     if [[ -n "${DRASI_SERVER_BIN:-}" ]]; then
         log "Using pre-set DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
+        DRASI_BUILD_SOURCE="preset ${DRASI_SERVER_BIN}"
         return 0
     fi
 
+    if [[ -n "$DRASI_SERVER_REF" ]]; then
+        build_drasi_server_from_source
+        return 0
+    fi
+
+    download_drasi_server_release
+}
+
+# Build drasi-server from a branch/tag/SHA of $DRASI_REPO using cargo, then set
+# DRASI_SERVER_BIN to the freshly built binary. Point DRASI_REPO at a fork to
+# build fork branches; $DRASI_SERVER_REF may be a branch, tag, or commit SHA.
+build_drasi_server_from_source() {
+    local ref="$DRASI_SERVER_REF"
+    local repo_url="https://github.com/${DRASI_REPO}.git"
+    log "Building drasi-server from source: repo=$DRASI_REPO ref=$ref"
+
+    rm -rf "$SRC_BUILD_DIR"
+    # Shallow branch/tag clone is fastest; fall back to a full clone + checkout
+    # when $ref is a commit SHA (which --branch does not accept).
+    if ! git clone --depth 1 --branch "$ref" "$repo_url" "$SRC_BUILD_DIR" 2>/dev/null; then
+        log "Shallow clone of ref '$ref' failed; retrying with full clone + checkout"
+        rm -rf "$SRC_BUILD_DIR"
+        git clone "$repo_url" "$SRC_BUILD_DIR"
+        git -C "$SRC_BUILD_DIR" checkout "$ref"
+    fi
+
+    local built_sha
+    built_sha="$(git -C "$SRC_BUILD_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    log "Checked out $DRASI_REPO @ $ref ($built_sha); running cargo build --release"
+
+    if ! ( cd "$SRC_BUILD_DIR" && cargo build --release --bin drasi-server ); then
+        log "cargo build --bin drasi-server failed; retrying default release build"
+        ( cd "$SRC_BUILD_DIR" && cargo build --release )
+    fi
+
+    local built_bin="$SRC_BUILD_DIR/target/release/drasi-server"
+    if [[ ! -x "$built_bin" ]]; then
+        # Bin name may differ from the crate default; locate it under target/release.
+        built_bin="$(find "$SRC_BUILD_DIR/target/release" -maxdepth 1 -type f -name 'drasi-server*' -perm -u+x 2>/dev/null | head -n1)"
+    fi
+    [[ -n "$built_bin" && -x "$built_bin" ]] || { log "ERROR: cargo build did not produce a drasi-server binary"; return 1; }
+
+    DRASI_SERVER_BIN="$built_bin"
+    export DRASI_SERVER_BIN
+    DRASI_BUILD_SOURCE="source ${DRASI_REPO}@${ref} (${built_sha})"
+    log "DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
+    "$DRASI_SERVER_BIN" --version || true
+}
+
+download_drasi_server_release() {
     mkdir -p "$DOWNLOAD_DIR"
     cd "$DOWNLOAD_DIR"
 
@@ -148,6 +211,7 @@ download_drasi_server() {
 
     DRASI_SERVER_BIN="$DOWNLOAD_DIR/drasi-server"
     export DRASI_SERVER_BIN
+    DRASI_BUILD_SOURCE="release ${tag} (${DRASI_REPO})"
     log "DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
     "$DRASI_SERVER_BIN" --version || true
     cd - >/dev/null
@@ -387,14 +451,14 @@ write_step_summary() {
     fi
 
     local out="$GITHUB_STEP_SUMMARY"
-    local drasi_version="${DRASI_SERVER_VERSION:-latest}"
+    local drasi_source="${DRASI_BUILD_SOURCE:-unknown}"
     local server_version
     server_version="$("$DRASI_SERVER_BIN" --version 2>/dev/null | head -n1 || echo unknown)"
 
     {
         echo "## E2E test summary — \`$TEST_RUN_ID\`"
         echo
-        echo "- drasi-server tag: \`$drasi_version\`"
+        echo "- drasi-server source: \`$drasi_source\`"
         echo "- drasi-server binary: \`$server_version\`"
         echo
 

--- a/e2e-test-framework/examples/building_comfort/ci/drasi_server_http/README.md
+++ b/e2e-test-framework/examples/building_comfort/ci/drasi_server_http/README.md
@@ -102,24 +102,13 @@ Client extension (or `curl`).
 | Test service HTTP reaction handler (per-room)      | 9001 (path `/reaction`) |
 | Test service HTTP reaction handler (floor-agg)     | 9002 (path `/reaction`) |
 
-## Running in CI against a drasi-server branch or fork
+## Running in CI
 
-The scheduled workflow ([`.github/workflows/e2e-building-comfort.yml`](../../../../../.github/workflows/e2e-building-comfort.yml))
-downloads the latest drasi-server release by default. To instead **build
-drasi-server from source** for this job, run it via *Actions → E2E -
-building_comfort → Run workflow* and set:
-
-- `drasi_server_ref` &mdash; a branch, tag, or commit SHA to build. Leaving
-  it empty keeps the default release-download behavior.
-- `drasi_server_repo` &mdash; the repo to build from (`owner/name`). Point it
-  at a fork to test a fork branch. Defaults to `drasi-project/drasi-server`.
-
-The runner (`run_test_ci.sh`) clones that repo/ref and runs
-`cargo build --release`, then uses the freshly built binary. The workflow
-step summary labels the run with the resolved source
-(`source <repo>@<ref> (<sha>)` or `release <tag> (<repo>)`) so results are
-traceable. The same behavior is available locally by exporting
-`DRASI_SERVER_REF` (and optionally `DRASI_REPO`) before running the script.
+This variant runs as the `building_comfort / drasi_server_http` job of the
+`E2E - building_comfort` workflow, which downloads the latest drasi-server
+release by default or builds from a branch/fork on demand. See
+[`../README.md`](../README.md) for how to trigger it and pass a
+`drasi_server_ref` / `drasi_server_repo`.
 
 ## Troubleshooting
 

--- a/e2e-test-framework/examples/building_comfort/ci/drasi_server_http/README.md
+++ b/e2e-test-framework/examples/building_comfort/ci/drasi_server_http/README.md
@@ -102,6 +102,25 @@ Client extension (or `curl`).
 | Test service HTTP reaction handler (per-room)      | 9001 (path `/reaction`) |
 | Test service HTTP reaction handler (floor-agg)     | 9002 (path `/reaction`) |
 
+## Running in CI against a drasi-server branch or fork
+
+The scheduled workflow ([`.github/workflows/e2e-building-comfort.yml`](../../../../../.github/workflows/e2e-building-comfort.yml))
+downloads the latest drasi-server release by default. To instead **build
+drasi-server from source** for this job, run it via *Actions → E2E -
+building_comfort → Run workflow* and set:
+
+- `drasi_server_ref` &mdash; a branch, tag, or commit SHA to build. Leaving
+  it empty keeps the default release-download behavior.
+- `drasi_server_repo` &mdash; the repo to build from (`owner/name`). Point it
+  at a fork to test a fork branch. Defaults to `drasi-project/drasi-server`.
+
+The runner (`run_test_ci.sh`) clones that repo/ref and runs
+`cargo build --release`, then uses the freshly built binary. The workflow
+step summary labels the run with the resolved source
+(`source <repo>@<ref> (<sha>)` or `release <tag> (<repo>)`) so results are
+traceable. The same behavior is available locally by exporting
+`DRASI_SERVER_REF` (and optionally `DRASI_REPO`) before running the script.
+
 ## Troubleshooting
 
 - **Connection refused on 9000** &mdash; Drasi Server is not running or the

--- a/e2e-test-framework/examples/building_comfort/ci/drasi_server_http/run_test_ci.sh
+++ b/e2e-test-framework/examples/building_comfort/ci/drasi_server_http/run_test_ci.sh
@@ -10,8 +10,9 @@
 # Scheduled / CI runner for the building_comfort / drasi_server_http E2E test.
 #
 # Responsibilities:
-#   1. Download the latest (or pinned) drasi-server release binary, unless
-#      DRASI_SERVER_BIN is already set.
+#   1. Obtain the drasi-server binary: download a release, build from a
+#      branch/tag/SHA ($DRASI_SERVER_REF) of $DRASI_REPO, or use a pre-set
+#      DRASI_SERVER_BIN.
 #   2. Patch the example configs so the run is CI-safe (port collision, keep
 #      artifacts on shutdown).
 #   3. Start drasi-server and the test-service as background processes.
@@ -22,9 +23,15 @@
 # or `curl` is used to fetch the release.
 #
 # Environment variables (with defaults):
-#   DRASI_REPO            GitHub repo for releases. Default: drasi-project/drasi-server
-#   DRASI_SERVER_VERSION  Release tag to download. Default: latest
-#   DRASI_SERVER_BIN      Pre-downloaded binary; skips the download step.
+#   DRASI_REPO            GitHub repo (owner/name) for the release download or
+#                         the source build. Default: drasi-project/drasi-server.
+#                         Point at a fork (e.g. myuser/drasi-server) to build a
+#                         fork branch.
+#   DRASI_SERVER_VERSION  Release tag to download. Default: latest (release mode).
+#   DRASI_SERVER_REF      Branch/tag/SHA to BUILD drasi-server from source with
+#                         cargo. When set, overrides the release download.
+#                         Empty = download the release binary (default).
+#   DRASI_SERVER_BIN      Pre-built binary; skips both download and source build.
 #   DRASI_ADMIN_PORT      Admin port to patch into drasi_server_config.yaml. Default: 8090
 #   DRASI_SOURCE_PORT     HTTP source port. Default: 9000
 #   TEST_SERVICE_PORT     test-service REST API port. Default: 63123
@@ -48,6 +55,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 DRASI_REPO="${DRASI_REPO:-drasi-project/drasi-server}"
 DRASI_SERVER_VERSION="${DRASI_SERVER_VERSION:-}"
+DRASI_SERVER_REF="${DRASI_SERVER_REF:-}"
 DRASI_ADMIN_PORT="${DRASI_ADMIN_PORT:-8090}"
 DRASI_SOURCE_PORT="${DRASI_SOURCE_PORT:-9000}"
 TEST_SERVICE_PORT="${TEST_SERVICE_PORT:-63123}"
@@ -60,6 +68,7 @@ WORK_DIR="${WORK_DIR:-$SCRIPT_DIR/.ci_work}"
 
 LOG_DIR="$WORK_DIR/logs"
 DOWNLOAD_DIR="$WORK_DIR/drasi-server-download"
+SRC_BUILD_DIR="$WORK_DIR/drasi-server-src"
 DATA_CACHE="$WORK_DIR/test_data_cache"
 DRASI_CFG_SRC="$SCRIPT_DIR/drasi_server_config.yaml"
 TEST_CFG_SRC="$SCRIPT_DIR/config.json"
@@ -70,6 +79,9 @@ mkdir -p "$WORK_DIR" "$LOG_DIR" "$ARTIFACTS_DIR"
 
 DRASI_PID=""
 SERVICE_PID=""
+# Human-readable description of where DRASI_SERVER_BIN came from (release tag,
+# source build, or preset). Surfaced in the step summary for result labeling.
+DRASI_BUILD_SOURCE=""
 
 log() { echo "[ci] $*"; }
 
@@ -113,9 +125,60 @@ wait_for_port() {
 download_drasi_server() {
     if [[ -n "${DRASI_SERVER_BIN:-}" ]]; then
         log "Using pre-set DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
+        DRASI_BUILD_SOURCE="preset ${DRASI_SERVER_BIN}"
         return 0
     fi
 
+    if [[ -n "$DRASI_SERVER_REF" ]]; then
+        build_drasi_server_from_source
+        return 0
+    fi
+
+    download_drasi_server_release
+}
+
+# Build drasi-server from a branch/tag/SHA of $DRASI_REPO using cargo, then set
+# DRASI_SERVER_BIN to the freshly built binary. Point DRASI_REPO at a fork to
+# build fork branches; $DRASI_SERVER_REF may be a branch, tag, or commit SHA.
+build_drasi_server_from_source() {
+    local ref="$DRASI_SERVER_REF"
+    local repo_url="https://github.com/${DRASI_REPO}.git"
+    log "Building drasi-server from source: repo=$DRASI_REPO ref=$ref"
+
+    rm -rf "$SRC_BUILD_DIR"
+    # Shallow branch/tag clone is fastest; fall back to a full clone + checkout
+    # when $ref is a commit SHA (which --branch does not accept).
+    if ! git clone --depth 1 --branch "$ref" "$repo_url" "$SRC_BUILD_DIR" 2>/dev/null; then
+        log "Shallow clone of ref '$ref' failed; retrying with full clone + checkout"
+        rm -rf "$SRC_BUILD_DIR"
+        git clone "$repo_url" "$SRC_BUILD_DIR"
+        git -C "$SRC_BUILD_DIR" checkout "$ref"
+    fi
+
+    local built_sha
+    built_sha="$(git -C "$SRC_BUILD_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    log "Checked out $DRASI_REPO @ $ref ($built_sha); running cargo build --release"
+
+    if ! ( cd "$SRC_BUILD_DIR" && cargo build --release --bin drasi-server ); then
+        log "cargo build --bin drasi-server failed; retrying default release build"
+        ( cd "$SRC_BUILD_DIR" && cargo build --release )
+    fi
+
+    local built_bin="$SRC_BUILD_DIR/target/release/drasi-server"
+    if [[ ! -x "$built_bin" ]]; then
+        # Bin name may differ from the crate default; locate it under target/release.
+        built_bin="$(find "$SRC_BUILD_DIR/target/release" -maxdepth 1 -type f -name 'drasi-server*' -perm -u+x 2>/dev/null | head -n1)"
+    fi
+    [[ -n "$built_bin" && -x "$built_bin" ]] || { log "ERROR: cargo build did not produce a drasi-server binary"; return 1; }
+
+    DRASI_SERVER_BIN="$built_bin"
+    export DRASI_SERVER_BIN
+    DRASI_BUILD_SOURCE="source ${DRASI_REPO}@${ref} (${built_sha})"
+    log "DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
+    "$DRASI_SERVER_BIN" --version || true
+}
+
+download_drasi_server_release() {
     mkdir -p "$DOWNLOAD_DIR"
     cd "$DOWNLOAD_DIR"
 
@@ -148,6 +211,7 @@ download_drasi_server() {
 
     DRASI_SERVER_BIN="$DOWNLOAD_DIR/drasi-server"
     export DRASI_SERVER_BIN
+    DRASI_BUILD_SOURCE="release ${tag} (${DRASI_REPO})"
     log "DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
     "$DRASI_SERVER_BIN" --version || true
     cd - >/dev/null
@@ -387,14 +451,14 @@ write_step_summary() {
     fi
 
     local out="$GITHUB_STEP_SUMMARY"
-    local drasi_version="${DRASI_SERVER_VERSION:-latest}"
+    local drasi_source="${DRASI_BUILD_SOURCE:-unknown}"
     local server_version
     server_version="$("$DRASI_SERVER_BIN" --version 2>/dev/null | head -n1 || echo unknown)"
 
     {
         echo "## E2E test summary — \`$TEST_RUN_ID\`"
         echo
-        echo "- drasi-server tag: \`$drasi_version\`"
+        echo "- drasi-server source: \`$drasi_source\`"
         echo "- drasi-server binary: \`$server_version\`"
         echo
 

--- a/e2e-test-framework/examples/stock_market/ci/drasi_server_http_grpc_join/README.md
+++ b/e2e-test-framework/examples/stock_market/ci/drasi_server_http_grpc_join/README.md
@@ -110,6 +110,26 @@ The CI script will:
 Artifacts (logs, captured JSONL, reaction state) land in
 `./ci_artifacts/`.
 
+## Running in CI against a drasi-server branch or fork
+
+This variant runs as the `stock_market / drasi_server_http_grpc_join` job of
+the [`E2E - stock_market join`](../../../../../.github/workflows/e2e-stock-market-join.yml)
+workflow. By default (scheduled or a plain manual run) it downloads the latest
+`drasi-project/drasi-server` release. To instead **build drasi-server from
+source**, trigger it via *Actions → E2E - stock_market join → Run workflow* and
+set:
+
+- `drasi_server_ref` &mdash; a branch, tag, or commit SHA to build. Empty keeps
+  the default release-download behavior.
+- `drasi_server_repo` &mdash; the repo to build from (`owner/name`). Point it at
+  a fork to test a fork branch. Empty defaults to `drasi-project/drasi-server`.
+
+The runner clones that repo/ref and runs `cargo build --release`, then uses the
+freshly built binary. The step summary labels the run with the resolved source
+(`source <repo>@<ref> (<sha>)` or `release <tag> (<repo>)`). The repo/branch must
+be pushed and public (the clone is anonymous). Locally, export `DRASI_SERVER_REF`
+(and optionally `DRASI_REPO`) before running the script for the same effect.
+
 ## Default ports
 
 | Component                                          | Port                    |

--- a/e2e-test-framework/examples/stock_market/ci/drasi_server_http_grpc_join/run_test_ci.sh
+++ b/e2e-test-framework/examples/stock_market/ci/drasi_server_http_grpc_join/run_test_ci.sh
@@ -12,8 +12,9 @@
 # synthetic multi-source join — and emit results via an HTTP reaction.
 #
 # Responsibilities:
-#   1. Download the latest (or pinned) drasi-server release binary, unless
-#      DRASI_SERVER_BIN is already set.
+#   1. Obtain the drasi-server binary: download a release, build from a
+#      branch/tag/SHA ($DRASI_SERVER_REF) of $DRASI_REPO, or use a pre-set
+#      DRASI_SERVER_BIN.
 #   2. Patch the example configs so the run is CI-safe (port collision, keep
 #      artifacts on shutdown).
 #   3. Start drasi-server and the test-service as background processes.
@@ -24,9 +25,15 @@
 # is used to fetch the release.
 #
 # Environment variables (with defaults):
-#   DRASI_REPO            GitHub repo for releases. Default: drasi-project/drasi-server
-#   DRASI_SERVER_VERSION  Release tag to download. Default: latest
-#   DRASI_SERVER_BIN      Pre-downloaded binary; skips the download step.
+#   DRASI_REPO            GitHub repo (owner/name) for the release download or
+#                         the source build. Default: drasi-project/drasi-server.
+#                         Point at a fork (e.g. myuser/drasi-server) to build a
+#                         fork branch.
+#   DRASI_SERVER_VERSION  Release tag to download. Default: latest (release mode).
+#   DRASI_SERVER_REF      Branch/tag/SHA to BUILD drasi-server from source with
+#                         cargo. When set, overrides the release download.
+#                         Empty = download the release binary (default).
+#   DRASI_SERVER_BIN      Pre-built binary; skips both download and source build.
 #   DRASI_ADMIN_PORT      Admin port to patch into drasi_server_config.yaml. Default: 8090
 #   DRASI_HTTP_PORT       HTTP source port. Default: 9000
 #   DRASI_GRPC_PORT       gRPC source port. Default: 50051
@@ -51,6 +58,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 DRASI_REPO="${DRASI_REPO:-drasi-project/drasi-server}"
 DRASI_SERVER_VERSION="${DRASI_SERVER_VERSION:-}"
+DRASI_SERVER_REF="${DRASI_SERVER_REF:-}"
 DRASI_ADMIN_PORT="${DRASI_ADMIN_PORT:-8090}"
 DRASI_HTTP_PORT="${DRASI_HTTP_PORT:-9000}"
 DRASI_GRPC_PORT="${DRASI_GRPC_PORT:-50051}"
@@ -64,6 +72,7 @@ WORK_DIR="${WORK_DIR:-$SCRIPT_DIR/.ci_work}"
 
 LOG_DIR="$WORK_DIR/logs"
 DOWNLOAD_DIR="$WORK_DIR/drasi-server-download"
+SRC_BUILD_DIR="$WORK_DIR/drasi-server-src"
 DATA_CACHE="$WORK_DIR/test_data_cache"
 DRASI_CFG_SRC="$SCRIPT_DIR/drasi_server_config.yaml"
 TEST_CFG_SRC="$SCRIPT_DIR/config.json"
@@ -74,6 +83,9 @@ mkdir -p "$WORK_DIR" "$LOG_DIR" "$ARTIFACTS_DIR"
 
 DRASI_PID=""
 SERVICE_PID=""
+# Human-readable description of where DRASI_SERVER_BIN came from (release tag,
+# source build, or preset). Surfaced in the step summary for result labeling.
+DRASI_BUILD_SOURCE=""
 
 log() { echo "[ci] $*"; }
 
@@ -117,9 +129,60 @@ wait_for_port() {
 download_drasi_server() {
     if [[ -n "${DRASI_SERVER_BIN:-}" ]]; then
         log "Using pre-set DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
+        DRASI_BUILD_SOURCE="preset ${DRASI_SERVER_BIN}"
         return 0
     fi
 
+    if [[ -n "$DRASI_SERVER_REF" ]]; then
+        build_drasi_server_from_source
+        return 0
+    fi
+
+    download_drasi_server_release
+}
+
+# Build drasi-server from a branch/tag/SHA of $DRASI_REPO using cargo, then set
+# DRASI_SERVER_BIN to the freshly built binary. Point DRASI_REPO at a fork to
+# build fork branches; $DRASI_SERVER_REF may be a branch, tag, or commit SHA.
+build_drasi_server_from_source() {
+    local ref="$DRASI_SERVER_REF"
+    local repo_url="https://github.com/${DRASI_REPO}.git"
+    log "Building drasi-server from source: repo=$DRASI_REPO ref=$ref"
+
+    rm -rf "$SRC_BUILD_DIR"
+    # Shallow branch/tag clone is fastest; fall back to a full clone + checkout
+    # when $ref is a commit SHA (which --branch does not accept).
+    if ! git clone --depth 1 --branch "$ref" "$repo_url" "$SRC_BUILD_DIR" 2>/dev/null; then
+        log "Shallow clone of ref '$ref' failed; retrying with full clone + checkout"
+        rm -rf "$SRC_BUILD_DIR"
+        git clone "$repo_url" "$SRC_BUILD_DIR"
+        git -C "$SRC_BUILD_DIR" checkout "$ref"
+    fi
+
+    local built_sha
+    built_sha="$(git -C "$SRC_BUILD_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    log "Checked out $DRASI_REPO @ $ref ($built_sha); running cargo build --release"
+
+    if ! ( cd "$SRC_BUILD_DIR" && cargo build --release --bin drasi-server ); then
+        log "cargo build --bin drasi-server failed; retrying default release build"
+        ( cd "$SRC_BUILD_DIR" && cargo build --release )
+    fi
+
+    local built_bin="$SRC_BUILD_DIR/target/release/drasi-server"
+    if [[ ! -x "$built_bin" ]]; then
+        # Bin name may differ from the crate default; locate it under target/release.
+        built_bin="$(find "$SRC_BUILD_DIR/target/release" -maxdepth 1 -type f -name 'drasi-server*' -perm -u+x 2>/dev/null | head -n1)"
+    fi
+    [[ -n "$built_bin" && -x "$built_bin" ]] || { log "ERROR: cargo build did not produce a drasi-server binary"; return 1; }
+
+    DRASI_SERVER_BIN="$built_bin"
+    export DRASI_SERVER_BIN
+    DRASI_BUILD_SOURCE="source ${DRASI_REPO}@${ref} (${built_sha})"
+    log "DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
+    "$DRASI_SERVER_BIN" --version || true
+}
+
+download_drasi_server_release() {
     mkdir -p "$DOWNLOAD_DIR"
     cd "$DOWNLOAD_DIR"
 
@@ -152,6 +215,7 @@ download_drasi_server() {
 
     DRASI_SERVER_BIN="$DOWNLOAD_DIR/drasi-server"
     export DRASI_SERVER_BIN
+    DRASI_BUILD_SOURCE="release ${tag} (${DRASI_REPO})"
     log "DRASI_SERVER_BIN=$DRASI_SERVER_BIN"
     "$DRASI_SERVER_BIN" --version || true
     cd - >/dev/null
@@ -358,14 +422,14 @@ write_step_summary() {
     fi
 
     local out="$GITHUB_STEP_SUMMARY"
-    local drasi_version="${DRASI_SERVER_VERSION:-latest}"
+    local drasi_source="${DRASI_BUILD_SOURCE:-unknown}"
     local server_version
     server_version="$("$DRASI_SERVER_BIN" --version 2>/dev/null | head -n1 || echo unknown)"
 
     {
         echo "## E2E test summary — \`$TEST_RUN_ID\`"
         echo
-        echo "- drasi-server tag: \`$drasi_version\`"
+        echo "- drasi-server source: \`$drasi_source\`"
         echo "- drasi-server binary: \`$server_version\`"
         echo
 


### PR DESCRIPTION
# Description

## Summary

Adds an on-demand path to run the E2E suites against an arbitrary **drasi-server**
branch, tag, SHA, or fork — without hand-editing any manifest. By default the
workflows still download the latest `drasi-project/drasi-server` release
(nightly behavior unchanged); when a ref is supplied, the runner builds
drasi-server from source and tests against that binary.

Part of #80. Scoped to the `building_comfort` and `stock_market` scenarios as
the first increment.

## What's included

**Workflows** (`workflow_dispatch` inputs, both default empty):
- `drasi_server_repo` — repo `owner/name` to build from (empty → `drasi-project/drasi-server`; set a fork here).
- `drasi_server_ref` — branch/tag/SHA to build from source (empty → download latest release).
- Removed the old `drasi_server_version` tag input.
- Applied to `e2e-building-comfort.yml` (http + grpc jobs) and `e2e-stock-market-join.yml`.

**Runner scripts** (`run_test_ci.sh` for the three drasi-server variants):
- New `build_drasi_server_from_source()`: clones the repo/ref (shallow, with full-clone+checkout fallback for SHAs) and runs `cargo build --release`.
- `download_drasi_server()` now dispatches: preset `DRASI_SERVER_BIN` → build-from-source (if `DRASI_SERVER_REF` set) → release download (default).
- Step summary labels each run with its resolved source: `source <repo>@<ref> (<sha>)` or `release <tag> (<repo>)`.

**drasi-core branch testing (drasi_lib variant):**
- Documented a git-based `[patch.crates-io]` override in `e2e-test-framework/Cargo.toml` so the embedded drasi-lib variant can build against a drasi-core branch/fork; the workflow just runs from the branch that carries the patch.

**Docs:**
- New `examples/building_comfort/ci/README.md` — single index covering all three CI variants and how to trigger them (default, branch/fork, and the drasi-core/drasi_lib path), plus where results appear.
- Trimmed the per-variant "Running in CI" sections to point at the index (removed duplication).
- Added an equivalent "Running in CI" section to the stock_market CI README.

## How to trigger

*Actions → E2E - building_comfort (or E2E - stock_market join) → Run workflow*:
- **Default:** leave inputs empty → latest release download.
- **Branch/fork:** set `drasi_server_ref` (+ optional `drasi_server_repo`, e.g. `my-user/drasi-server`).

The target repo/branch must be pushed and public (the clone is anonymous).


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Drasi and do not have an associated issue link please create one now.

-->

- This pull request fixes a bug in Drasi and has an approved issue (issue link required).
- This pull request adds or changes features of Drasi and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Drasi (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
